### PR TITLE
Fix copy from create table

### DIFF
--- a/s3filepath/s3filepath.go
+++ b/s3filepath/s3filepath.go
@@ -120,13 +120,13 @@ func FindLatestInputData(bucket Bucketer, schema, table string, targetDate *time
 		// ignore malformed s3 files
 		if errDate != nil || errZip != nil {
 			log.Printf("ignoring file: %s, errs are: %s, %s", item.Key, errDate, errZip)
-		} else {
-			if targetDate != nil && !targetDate.Equal(returnDate) {
-				log.Printf("date set to %s, ignoring non-matching file: %s with date: %s", *targetDate, item.Key, returnDate)
-			} else {
-				return returnDate, suffix, nil
-			}
+			continue
 		}
+		if targetDate != nil && !targetDate.Equal(returnDate) {
+			log.Printf("date set to %s, ignoring non-matching file: %s with date: %s", *targetDate, item.Key, returnDate)
+			continue
+		}
+		return returnDate, suffix, nil
 	}
 	notFoundErr := fmt.Errorf("%d files found, but none found with search path: 's3://%s/%s' and date (if set) %s Most recent: %s",
 		len(items), bucket.Name(), search, targetDate, items[0].Key)

--- a/s3filepath/s3filepath.go
+++ b/s3filepath/s3filepath.go
@@ -13,7 +13,8 @@ import (
 
 var (
 	// currently assumes no unix file created timestamp
-	s3Regex = regexp.MustCompile(".*_.*_(.*?)\\.(.*)")
+	s3Regex   = regexp.MustCompile(".*_.*_(.*?)\\.(.*)")
+	yamlRegex = regexp.MustCompile(".*\\.yml")
 )
 
 // Bucketer interface is useful for testing and showing that
@@ -124,6 +125,10 @@ func FindLatestInputData(bucket Bucketer, schema, table string, targetDate *time
 		}
 		if targetDate != nil && !targetDate.Equal(returnDate) {
 			log.Printf("date set to %s, ignoring non-matching file: %s with date: %s", *targetDate, item.Key, returnDate)
+			continue
+		}
+		if yamlRegex.MatchString(item.Key) {
+			log.Printf("ignoring yaml file: %s, we are looking for data files", item.Key)
 			continue
 		}
 		return returnDate, suffix, nil


### PR DESCRIPTION
Needed to make sure we didn't pick up on the config file if the config name happened to match the prefix of the data.

for instance:
`mongo_sis_config_x.yml`
`mongo_students_x.yml`
was working fine, but:
`mongo_apprequests_config_x.yml`
`mongo_apprequests_x.yml`
was confusing s3-to-redshift.