### PR TITLE
Fix date issue

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -294,7 +294,7 @@ func (r *Redshift) UpdateTable(tx *sql.Tx, targetTable, inputTable Table) error 
 		}
 	}
 	if len(columnOps) == 0 {
-		log.Println("no update necessary")
+		log.Println("no schema update necessary")
 		return nil
 	}
 

--- a/s3filepath/s3filepath.go
+++ b/s3filepath/s3filepath.go
@@ -101,7 +101,8 @@ func FindLatestInputData(bucket Bucketer, schema, table string, targetDate *time
 	var suffix string
 	// when we list, we want all files that look like <schema>_<table> and we look at the dates
 	search := fmt.Sprintf("%s_%s", schema, table)
-	maxKeys := 10000 // perhaps configure, right now this seems like a fine default
+	// can never ask for > 1000: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
+	maxKeys := 1000
 	listRes, err := bucket.List(search, "", "", maxKeys)
 	if err != nil {
 		return returnDate, suffix, err


### PR DESCRIPTION
This will just actually error when we hit the limit - we should figure out a better way to do this, but for now I've deleted some old files to get us under the limit.

I think we should store longer copies of the data for later processing in some smart way - right now we can only keep around about a month's worth of data before querying hits the 1000 item limit, and in any case that gets awkward over 1000 generally

Linked in the code, docs about 1000: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html