### PR TITLE
increase gearcmd timeout for data copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ RUN curl -L https://github.com/Clever/gearcmd/releases/download/v0.4.0/gearcmd-v
 
 COPY bin/s3-to-redshift /usr/bin/s3-to-redshift
 
-CMD ["gearcmd", "--name", "s3-to-redshift", "--cmd", "s3-to-redshift", "--cmdtimeout",  "59m"]
+# Ideally we should take less than 2 hours (copy should be fast), in the future check this value again
+CMD ["gearcmd", "--name", "s3-to-redshift", "--cmd", "s3-to-redshift", "--cmdtimeout",  "2h"]


### PR DESCRIPTION
ideally this will take less time, but until we figure out how to address the issue, let's increase the timeout to 2 hours