### PR TITLE
Revert "increase gearcmd timeout for data copy"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,4 @@ RUN curl -L https://github.com/Clever/gearcmd/releases/download/v0.4.0/gearcmd-v
 
 COPY bin/s3-to-redshift /usr/bin/s3-to-redshift
 
-# Ideally we should take less than 2 hours (copy should be fast), in the future check this value again
-CMD ["gearcmd", "--name", "s3-to-redshift", "--cmd", "s3-to-redshift", "--cmdtimeout",  "2h"]
+CMD ["gearcmd", "--name", "s3-to-redshift", "--cmd", "s3-to-redshift", "--cmdtimeout",  "59m"]


### PR DESCRIPTION
Reverts Clever/s3-to-redshift#42

This didn't help, and I'd prefer the shorter timeout.
We're opening a ticket with Amazon about why this is failing, instead.