### PR TITLE
Support manifest files

### DIFF
--- a/cmd/s3_to_redshift.go
+++ b/cmd/s3_to_redshift.go
@@ -44,7 +44,7 @@ func fatalIfErr(err error, msg string) {
 	}
 }
 
-// in a transaction, truncate, create or update, and then copy from the s3 JSON file
+// in a transaction, truncate, create or update, and then copy from the s3 JSON file or manifest
 // yell loudly if there is anything different in the target table compared to config (different distkey, etc)
 func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable redshift.Table, targetTable *redshift.Table, truncate, gzip bool) error {
 	tx, err := db.Begin()
@@ -70,8 +70,6 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 	}
 
 	// COPY direct into it, ok to do since we're in a transaction
-	// assuming that we always want to copy from s3, so that parameter is always true
-	// if we want to change that, we should figure this out from the filename
 	if err = db.JSONCopy(tx, inputConf, true, gzip); err != nil {
 		return fmt.Errorf("err running JSON copy: %s", err)
 	}

--- a/cmd/s3_to_redshift.go
+++ b/cmd/s3_to_redshift.go
@@ -25,6 +25,7 @@ var (
 	force           = flag.Bool("force", false, "do we refresh the data even if it's already handled?")
 	dataDate        = flag.String("date", "", "data date we should process, must be full RFC3339")
 	configFile      = flag.String("config", "", "schema & table config to use in YAML format")
+	gzip            = flag.Bool("gzip", true, "whether target files are gzipped, defaults to true")
 	// things which will would strongly suggest launching as a second worker are env vars
 	// also the secrets ... shhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
 	host               = os.Getenv("REDSHIFT_HOST")
@@ -45,7 +46,7 @@ func fatalIfErr(err error, msg string) {
 
 // in a transaction, truncate, create or update, and then copy from the s3 JSON file
 // yell loudly if there is anything different in the target table compared to config (different distkey, etc)
-func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable redshift.Table, targetTable *redshift.Table, truncate bool) error {
+func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable redshift.Table, targetTable *redshift.Table, truncate, gzip bool) error {
 	tx, err := db.Begin()
 	if err != nil {
 		return err
@@ -69,12 +70,8 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 	}
 
 	// COPY direct into it, ok to do since we're in a transaction
-	// assuming that we always want to copy from s3 and have gzip, so last 2 params are true
+	// assuming that we always want to copy from s3, so that parameter is always true
 	// if we want to change that, we should figure this out from the filename
-	gzip := false
-	if strings.Contains(inputConf.Suffix, "gz") {
-		gzip = true
-	}
 	if err = db.JSONCopy(tx, inputConf, true, gzip); err != nil {
 		return fmt.Errorf("err running JSON copy: %s", err)
 	}
@@ -135,7 +132,7 @@ func main() {
 			log.Printf("Forcing update of inputTable: %s", inputConf.Table)
 		}
 
-		fatalIfErr(runCopy(db, *inputConf, *inputTable, targetTable, *truncate), "Issue running copy")
+		fatalIfErr(runCopy(db, *inputConf, *inputTable, targetTable, *truncate, *gzip), "Issue running copy")
 		// DON'T NEED TO CREATE VIEWS - will be handled by the refresh script
 		log.Printf("done with table: %s.%s", inputConf.Schema, t)
 	}

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -328,7 +328,11 @@ func (r *Redshift) JSONCopy(tx *sql.Tx, f s3filepath.S3File, creds, gzip bool) e
 	if gzip {
 		gzipSQL = "GZIP"
 	}
-	copySQL := fmt.Sprintf(`COPY "%s"."%s" FROM '%s' WITH %s JSON '%s' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON %s`, f.Schema, f.Table, f.GetDataFilename(), gzipSQL, f.JSONPaths, f.Bucket.Region, credSQL)
+	manifestSQL := ""
+	if f.Suffix == "manifest" {
+		manifestSQL = "manifest"
+	}
+	copySQL := fmt.Sprintf(`COPY "%s"."%s" FROM '%s' WITH %s JSON '%s' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON %s %s`, f.Schema, f.Table, f.GetDataFilename(), gzipSQL, f.JSONPaths, f.Bucket.Region, manifestSQL, credSQL)
 	fullCopySQL := fmt.Sprintf(fmt.Sprintf(copySQL, credArgs...))
 	log.Printf("Running command: %s", copySQL)
 	// can't use prepare b/c of redshift-specific syntax that postgres does not like

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -315,6 +315,7 @@ func (r *Redshift) UpdateTable(tx *sql.Tx, targetTable, inputTable Table) error 
 }
 
 // JSONCopy copies JSON data present in an S3 file into a redshift table.
+// It also supports JSON data pointed at by a manifest file, if you pass in a manifest file.
 // this is meant to be run in a transaction, so the first arg must be a sql.Tx
 // if not using jsonPaths, set s3File.JSONPaths to "auto"
 func (r *Redshift) JSONCopy(tx *sql.Tx, f s3filepath.S3File, creds, gzip bool) error {

--- a/s3filepath/s3filepath_test.go
+++ b/s3filepath/s3filepath_test.go
@@ -41,6 +41,7 @@ func TestCreateS3File(t *testing.T) {
 		bucket, schema, table, expectedDate.Format(time.RFC3339))
 	jsonPath := "s3://b/s_t_2015-11-10T23:00:00Z.json"
 	jsonGzipPath := "s3://b/s_t_2015-11-10T23:00:00Z.json.gz"
+	manifestPath := "s3://b/s_t_2015-11-10T23:00:00Z.manifest"
 
 	// test completely non-existent file
 	expFile := getTestFileWithResults(bucket, schema, table, region, accessID, secretKey, expConf, "json.gz", expectedDate)
@@ -61,6 +62,17 @@ func TestCreateS3File(t *testing.T) {
 	expFile = getTestFileWithResults(bucket, schema, table, region, accessID, secretKey, expConf, "json", expectedDate)
 	testFiles = map[string]bool{
 		jsonPath: true,
+	}
+	returnedFile, err = CreateS3File(MockPathChecker{testFiles}, expFile.Bucket, schema, table, "", expectedDate)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expFile, *returnedFile)
+
+	// test generated manifest conf file
+	expFile = getTestFileWithResults(bucket, schema, table, region, accessID, secretKey, expConf, "manifest", expectedDate)
+	testFiles = map[string]bool{
+		manifestPath: true,
+		jsonGzipPath: true,
+		jsonPath:     true,
 	}
 	returnedFile, err = CreateS3File(MockPathChecker{testFiles}, expFile.Bucket, schema, table, "", expectedDate)
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
We need to support manifest files once the data gets above ~500 MB (compressed)
This adds manifest file support and gives more control over gzip, as well as makes some improvements to the tests.