### PR TITLE
Increase timeout to 90m

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN curl -L https://github.com/Clever/gearcmd/releases/download/v0.4.0/gearcmd-v
 
 COPY bin/s3-to-redshift /usr/bin/s3-to-redshift
 
-CMD ["gearcmd", "--name", "s3-to-redshift", "--cmd", "s3-to-redshift", "--cmdtimeout",  "59m"]
+CMD ["gearcmd", "--name", "s3-to-redshift", "--cmd", "s3-to-redshift", "--cmdtimeout",  "90m"]


### PR DESCRIPTION
Based on runs from last week and today we shouldn't need more than 90 mins to run the initial copy command and analyze command (and the first command may not be needed more than once!)
https://www.dropbox.com/s/f0n91susxgsqfih/Screenshot%202016-04-11%2017.23.59.png?dl=0