### PR TITLE
increasing size of longtext to be really long

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -96,7 +96,7 @@ var (
 		"int":       "integer",
 		"timestamp": "timestamp without time zone", // timestamp with timezone is not supported in redshift
 		"text":      "character varying(256)",      // unfortunately redshift turns text -> varchar 256
-		"longtext":  "character varying(10000)",    // when you actually need more than 256 characters
+		"longtext":  "character varying(65535)",    // when you actually need more than 256 characters
 	}
 )
 

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -211,7 +211,7 @@ func TestCreateTable(t *testing.T) {
 	regex := `CREATE TABLE ".*".".*".*` +
 		`test1 integer DEFAULT 100 NOT NULL SORTKEY.*` +
 		`DISTKEY.*id character varying\(256\).*PRIMARY KEY.*` +
-		`somelongtext character varying\(10000\).*` // a little awk, but the prepare makes sure this is good
+		`somelongtext character varying\(65535\).*` // a little awk, but the prepare makes sure this is good
 
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)


### PR DESCRIPTION
We need a longer `longtext` for some of the use cases we are considering. Discussed with @schimmy and he recommended modifying the existing `longtext` instead of adding another one, since `longtext` is not widely used right now.