### PR TITLE
Ip 847 allow csv with delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The `schema`, `tables`, and `bucket` flags also are critical. `granularity` is r
 - `force`: refresh the data even if the data date is after the current `s3` input date
 - `date`:  the date string for the data in question
 - `config`: override of the usual auto-discovery of the config
+- `delimiter`: required to use CSV files, what the file is delimited in (likely use the '|' pipe character as that is AWS' default)
 - `granularity`: how often we expect to append new data for each table (i.e. daily, or hourly buckets)
 
 #### Note on general usage:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The `schema`, `tables`, and `bucket` flags also are critical. `granularity` is r
 - `force`: refresh the data even if the data date is after the current `s3` input date
 - `date`:  the date string for the data in question
 - `config`: override of the usual auto-discovery of the config
-- `delimiter`: required to use CSV files, what the file is delimited in (likely use the '|' pipe character as that is AWS' default)
+- `delimiter`: required to use CSV files, what the file is delimited in (likely use the '|' pipe character as that is AWS' default). If `""` then JSON copy is assumed
 - `granularity`: how often we expect to append new data for each table (i.e. daily, or hourly buckets)
 
 #### Note on general usage:
@@ -121,7 +121,7 @@ Currently supported granularities are `hour` and `day`.
 Assuming that environment variables have been set:
 ```
 go run cmd/s3_to_redshift.go -schema=api_hits -tables=pages,sessions \
-  -bucket=analytics -config=s3://analytics/api.yml -date=2015-07-01T00:00:00Z -force=true
+  -bucket=analytics -config=s3://analytics/api.yml -date=2015-07-01T00:00:00Z -force=true -delimiter="|"
 ```
 
 ## Vendoring

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -315,11 +315,11 @@ func (r *Redshift) UpdateTable(tx *sql.Tx, targetTable, inputTable Table) error 
 	return nil
 }
 
-// Copy copies JSON data present in an S3 file into a redshift table.
-// It also supports JSON data pointed at by a manifest file, if you pass in a manifest file.
+// Copy copies either CSV or JSON data present in an S3 file into a redshift table.
+// It also supports CSV or JSON data pointed at by a manifest file, if you pass in a manifest file.
 // this is meant to be run in a transaction, so the first arg must be a sql.Tx
 // if not using jsonPaths, set s3File.JSONPaths to "auto"
-func (r *Redshift) Copy(tx *sql.Tx, f s3filepath.S3File, creds, gzip bool) error {
+func (r *Redshift) Copy(tx *sql.Tx, f s3filepath.S3File, delimiter string, creds, gzip bool) error {
 	var credSQL string
 	var credArgs []interface{}
 	if creds {
@@ -335,9 +335,18 @@ func (r *Redshift) Copy(tx *sql.Tx, f s3filepath.S3File, creds, gzip bool) error
 		manifestSQL = "manifest"
 	}
 
-	jsonPathsSQL := "'auto'"
+	// default to CSV
+	jsonSQL := ""
+	jsonPathsSQL := ""
+	delimSQL := fmt.Sprintf("DELIMITER AS '%s' REMOVEQUOTES TRIMBLANKS EMPTYASNULL ACCEPTANYDATE", delimiter) // always removequotes, UNLOAD should add quotes
+	// figure out if we're doing JSON - no delim means JSON
+	if delimiter == "" {
+		jsonSQL = "JSON"
+		jsonPathsSQL = "'auto'"
+		delimSQL = ""
+	}
 	copySQL := fmt.Sprintf(`COPY "%s"."%s" FROM '%s' WITH %s %s %s REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON %s %s %s`,
-		f.Schema, f.Table, f.GetDataFilename(), gzipSQL, jsonSQL, jsonPathsSQL, f.Bucket.Region, manifestSQL, credSQL)
+		f.Schema, f.Table, f.GetDataFilename(), gzipSQL, jsonSQL, jsonPathsSQL, f.Bucket.Region, manifestSQL, credSQL, delimSQL)
 	fullCopySQL := fmt.Sprintf(fmt.Sprintf(copySQL, credArgs...))
 	log.Printf("Running command: %s", copySQL)
 	// can't use prepare b/c of redshift-specific syntax that postgres does not like

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -334,7 +334,10 @@ func (r *Redshift) Copy(tx *sql.Tx, f s3filepath.S3File, creds, gzip bool) error
 	if f.Suffix == "manifest" {
 		manifestSQL = "manifest"
 	}
-	copySQL := fmt.Sprintf(`COPY "%s"."%s" FROM '%s' WITH %s JSON '%s' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON %s %s`, f.Schema, f.Table, f.GetDataFilename(), gzipSQL, f.JSONPaths, f.Bucket.Region, manifestSQL, credSQL)
+
+	jsonPathsSQL := "'auto'"
+	copySQL := fmt.Sprintf(`COPY "%s"."%s" FROM '%s' WITH %s %s %s REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON %s %s %s`,
+		f.Schema, f.Table, f.GetDataFilename(), gzipSQL, jsonSQL, jsonPathsSQL, f.Bucket.Region, manifestSQL, credSQL)
 	fullCopySQL := fmt.Sprintf(fmt.Sprintf(copySQL, credArgs...))
 	log.Printf("Running command: %s", copySQL)
 	// can't use prepare b/c of redshift-specific syntax that postgres does not like

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -315,11 +315,11 @@ func (r *Redshift) UpdateTable(tx *sql.Tx, targetTable, inputTable Table) error 
 	return nil
 }
 
-// JSONCopy copies JSON data present in an S3 file into a redshift table.
+// Copy copies JSON data present in an S3 file into a redshift table.
 // It also supports JSON data pointed at by a manifest file, if you pass in a manifest file.
 // this is meant to be run in a transaction, so the first arg must be a sql.Tx
 // if not using jsonPaths, set s3File.JSONPaths to "auto"
-func (r *Redshift) JSONCopy(tx *sql.Tx, f s3filepath.S3File, creds, gzip bool) error {
+func (r *Redshift) Copy(tx *sql.Tx, f s3filepath.S3File, creds, gzip bool) error {
 	var credSQL string
 	var credArgs []interface{}
 	if creds {

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -338,7 +338,9 @@ func (r *Redshift) Copy(tx *sql.Tx, f s3filepath.S3File, delimiter string, creds
 	// default to CSV
 	jsonSQL := ""
 	jsonPathsSQL := ""
-	delimSQL := fmt.Sprintf("DELIMITER AS '%s' REMOVEQUOTES TRIMBLANKS EMPTYASNULL ACCEPTANYDATE", delimiter) // always removequotes, UNLOAD should add quotes
+	// always removequotes, UNLOAD should add quotes
+	// always say escape for CSVs, UNLOAD should always escape
+	delimSQL := fmt.Sprintf("DELIMITER AS '%s' REMOVEQUOTES ESCAPE TRIMBLANKS EMPTYASNULL ACCEPTANYDATE", delimiter)
 	// figure out if we're doing JSON - no delim means JSON
 	if delimiter == "" {
 		jsonSQL = "JSON"

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -52,12 +52,11 @@ func TestTableFromConf(t *testing.T) {
 	}
 
 	f := s3filepath.S3File{
-		Bucket:    b,
-		Schema:    schema,
-		Table:     table,
-		JSONPaths: "auto",
-		Suffix:    "json.gz",
-		DataDate:  time.Now(),
+		Bucket:   b,
+		Schema:   schema,
+		Table:    table,
+		Suffix:   "json.gz",
+		DataDate: time.Now(),
 	}
 
 	// valid
@@ -363,18 +362,17 @@ func TestJSONCopy(t *testing.T) {
 	bucket, region, accessID, secretKey := "bucket", "region", "accessID", "secretKey"
 	b := s3filepath.S3Bucket{bucket, region, accessID, secretKey}
 	s3File := s3filepath.S3File{
-		Bucket:    b,
-		Schema:    schema,
-		Table:     table,
-		JSONPaths: "auto",
-		Suffix:    "json.gz",
-		DataDate:  time.Now(),
-		ConfFile:  "",
+		Bucket:   b,
+		Schema:   schema,
+		Table:    table,
+		Suffix:   "json.gz",
+		DataDate: time.Now(),
+		ConfFile: "",
 	}
 	// test with creds and GZIP
-	sql := `COPY "%s"."%s" FROM '%s' WITH %s JSON '%s' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`
+	sql := `COPY "%s"."%s" FROM '%s' WITH %s JSON 'auto' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`
 	execRegex := fmt.Sprintf(sql, schema, table, s3File.GetDataFilename(),
-		"GZIP", "auto", region, accessID, secretKey)
+		"GZIP", region, accessID, secretKey)
 
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
@@ -395,9 +393,8 @@ func TestJSONCopy(t *testing.T) {
 	}
 
 	// test with neither creds nor GZIP
-	sql = `COPY "%s"."%s" FROM '%s' WITH%s JSON '%s' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON`
-	execRegex = fmt.Sprintf(sql, schema, table, s3File.GetDataFilename(),
-		"", "auto", region)
+	sql = `COPY "%s"."%s" FROM '%s' WITH%s JSON 'auto' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON`
+	execRegex = fmt.Sprintf(sql, schema, table, s3File.GetDataFilename(), "", region)
 
 	db, mock, err = sqlmock.New()
 	assert.NoError(t, err)
@@ -418,23 +415,22 @@ func TestJSONCopy(t *testing.T) {
 	}
 }
 
-func TestManifestCopy(t *testing.T) {
+func TestJSONManifestCopy(t *testing.T) {
 	schema, table := "testschema", "tablename"
 	bucket, region, accessID, secretKey := "bucket", "region", "accessID", "secretKey"
 	b := s3filepath.S3Bucket{bucket, region, accessID, secretKey}
 	s3File := s3filepath.S3File{
-		Bucket:    b,
-		Schema:    schema,
-		Table:     table,
-		JSONPaths: "auto",
-		Suffix:    "manifest",
-		DataDate:  time.Now(),
-		ConfFile:  "",
+		Bucket:   b,
+		Schema:   schema,
+		Table:    table,
+		Suffix:   "manifest",
+		DataDate: time.Now(),
+		ConfFile: "",
 	}
 	// test with creds and GZIP
-	sql := `COPY "%s"."%s" FROM '%s' WITH %s JSON '%s' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON manifest CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`
+	sql := `COPY "%s"."%s" FROM '%s' WITH %s JSON 'auto' REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON manifest CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`
 	execRegex := fmt.Sprintf(sql, schema, table, s3File.GetDataFilename(),
-		"GZIP", "auto", region, accessID, secretKey)
+		"GZIP", region, accessID, secretKey)
 
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -126,7 +126,7 @@ func TestGetTableMetadata(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	// test normal operation
 	//   - test existence of table
@@ -155,9 +155,9 @@ func TestGetTableMetadata(t *testing.T) {
 	mock.ExpectQuery(dateRegex).WithArgs().WillReturnRows(dateRows)
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	returnedTable, returnedDate, err := mockrs.GetTableMetadata(schema, table, dataDateCol)
+	returnedTable, returnedDate, err := mockRedshift.GetTableMetadata(schema, table, dataDateCol)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTable, *returnedTable)
 	assert.Equal(t, expectedDate, *returnedDate)
@@ -177,9 +177,9 @@ func TestGetTableMetadata(t *testing.T) {
 	mock.ExpectQuery(existRegex).WithArgs().WillReturnError(sql.ErrNoRows)
 	mock.ExpectCommit()
 
-	tx, err = mockrs.Begin()
+	tx, err = mockRedshift.Begin()
 	assert.NoError(t, err)
-	returnedTable, returnedDate, err = mockrs.GetTableMetadata(schema, table, dataDateCol)
+	returnedTable, returnedDate, err = mockRedshift.GetTableMetadata(schema, table, dataDateCol)
 	assert.Error(t, err)
 	assert.Equal(t, sql.ErrNoRows, err)
 	assert.Nil(t, returnedTable)
@@ -215,16 +215,16 @@ func TestCreateTable(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectPrepare("This needs to be here, but not evaluated")
 	mock.ExpectExec(regex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.CreateTable(tx, dbTable))
+	assert.NoError(t, mockRedshift.CreateTable(tx, dbTable))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -262,15 +262,15 @@ func TestUpdateTable(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	// test no update
 	mock.ExpectBegin()
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.UpdateTable(tx, targetTable, inputTable))
+	assert.NoError(t, mockRedshift.UpdateTable(tx, targetTable, inputTable))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -300,9 +300,9 @@ func TestUpdateTable(t *testing.T) {
 		},
 		Meta: Meta{Schema: schema},
 	}
-	tx, err = mockrs.Begin()
+	tx, err = mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.UpdateTable(tx, fewerColumnsTargetTable, inputTable))
+	assert.NoError(t, mockRedshift.UpdateTable(tx, fewerColumnsTargetTable, inputTable))
 	assert.NoError(t, tx.Commit())
 
 	// test extra columns (no error currently)
@@ -317,9 +317,9 @@ func TestUpdateTable(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectCommit()
 
-	tx, err = mockrs.Begin()
+	tx, err = mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.UpdateTable(tx, targetTable, fewerColumnsInputTable))
+	assert.NoError(t, mockRedshift.UpdateTable(tx, targetTable, fewerColumnsInputTable))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -344,9 +344,9 @@ func TestUpdateTable(t *testing.T) {
 		mock.ExpectBegin()
 		mock.ExpectCommit()
 
-		tx, err = mockrs.Begin()
+		tx, err = mockRedshift.Begin()
 		assert.NoError(t, err)
-		err = mockrs.UpdateTable(tx, targetTable, mismatchingColInputTable)
+		err = mockRedshift.UpdateTable(tx, targetTable, mismatchingColInputTable)
 		log.Println("mismatch err: ", err)
 		assert.Error(t, err)
 		assert.NoError(t, tx.Commit())
@@ -377,15 +377,15 @@ func TestJSONCopy(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.Copy(tx, s3File, "", true, true))
+	assert.NoError(t, mockRedshift.Copy(tx, s3File, "", true, true))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -399,15 +399,15 @@ func TestJSONCopy(t *testing.T) {
 	db, mock, err = sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs = Redshift{db}
+	mockRedshift = Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err = mockrs.Begin()
+	tx, err = mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.Copy(tx, s3File, "", false, false))
+	assert.NoError(t, mockRedshift.Copy(tx, s3File, "", false, false))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -435,15 +435,15 @@ func TestJSONManifestCopy(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.Copy(tx, s3File, "", true, true))
+	assert.NoError(t, mockRedshift.Copy(tx, s3File, "", true, true))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -456,16 +456,16 @@ func TestTruncate(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectPrepare(fmt.Sprintf(`DELETE FROM "%s"."%s"`, schema, table))
 	mock.ExpectExec(`DELETE FROM ".*".".*"`).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.Truncate(tx, schema, table))
+	assert.NoError(t, mockRedshift.Truncate(tx, schema, table))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -493,15 +493,15 @@ func TestCSVCopy(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.Copy(tx, s3File, "|", true, true))
+	assert.NoError(t, mockRedshift.Copy(tx, s3File, "|", true, true))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -515,15 +515,15 @@ func TestCSVCopy(t *testing.T) {
 	db, mock, err = sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs = Redshift{db}
+	mockRedshift = Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err = mockrs.Begin()
+	tx, err = mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.Copy(tx, s3File, "|", false, false))
+	assert.NoError(t, mockRedshift.Copy(tx, s3File, "|", false, false))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -551,15 +551,15 @@ func TestCSVManifestCopy(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.Copy(tx, s3File, "|", true, true))
+	assert.NoError(t, mockRedshift.Copy(tx, s3File, "|", true, true))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -576,16 +576,16 @@ func TestTruncateInTimeRange(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 
 	mock.ExpectBegin()
 	mock.ExpectPrepare(fmt.Sprintf(`DELETE FROM "%s"."%s" WHERE date_trunc('%s', "time") = date_trunc('%s', timestamp '%s')`, schema, table, granularity, granularity, dateString))
 	mock.ExpectExec(`DELETE FROM ".*".".*" WHERE date_trunc\('.*', "time"\) = date_trunc\('.*', timestamp '.*'\)`).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	tx, err := mockrs.Begin()
+	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.TruncateInTimeRange(tx, schema, table, dataDate, granularity, timeColumn))
+	assert.NoError(t, mockRedshift.TruncateInTimeRange(tx, schema, table, dataDate, granularity, timeColumn))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -597,8 +597,8 @@ func TestVacuumAnalyzeTable(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockrs := Redshift{db}
+	mockRedshift := Redshift{db}
 	mock.ExpectExec(`VACUUM FULL`).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(`ANALYZE`).WillReturnResult(sqlmock.NewResult(0, 0))
-	assert.NoError(t, mockrs.VacuumAnalyze())
+	assert.NoError(t, mockRedshift.VacuumAnalyze())
 }

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -387,7 +387,7 @@ func TestJSONCopy(t *testing.T) {
 
 	tx, err := mockrs.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.JSONCopy(tx, s3File, true, true))
+	assert.NoError(t, mockrs.Copy(tx, s3File, true, true))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -410,7 +410,7 @@ func TestJSONCopy(t *testing.T) {
 
 	tx, err = mockrs.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.JSONCopy(tx, s3File, false, false))
+	assert.NoError(t, mockrs.Copy(tx, s3File, false, false))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {
@@ -447,7 +447,7 @@ func TestManifestCopy(t *testing.T) {
 
 	tx, err := mockrs.Begin()
 	assert.NoError(t, err)
-	assert.NoError(t, mockrs.JSONCopy(tx, s3File, true, true))
+	assert.NoError(t, mockrs.Copy(tx, s3File, true, true))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -486,7 +486,7 @@ func TestCSVCopy(t *testing.T) {
 		ConfFile: "",
 	}
 	// test with creds and GZIP
-	sql := `COPY "%s"."%s" FROM '%s' WITH %s REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s' DELIMITER AS '|' EMPTYASNULL ACCEPTANYDATE`
+	sql := `COPY "%s"."%s" FROM '%s' WITH %s REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s' DELIMITER AS '|' REMOVQUOTES ESCAPE EMPTYASNULL ACCEPTANYDATE`
 	execRegex := fmt.Sprintf(sql, schema, table, s3File.GetDataFilename(),
 		"GZIP", region, accessID, secretKey)
 
@@ -509,7 +509,7 @@ func TestCSVCopy(t *testing.T) {
 	}
 
 	// test with neither creds nor GZIP
-	sql = `COPY "%s"."%s" FROM '%s' WITH %s REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON DELIMITER AS '|' REMOVEQUOTES TRIMBLANKS EMPTYASNULL ACCEPTANYDATE`
+	sql = `COPY "%s"."%s" FROM '%s' WITH %s REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON DELIMITER AS '|' REMOVEQUOTES ESCAPE TRIMBLANKS EMPTYASNULL ACCEPTANYDATE`
 	execRegex = fmt.Sprintf(sql, schema, table, s3File.GetDataFilename(), "", region)
 
 	db, mock, err = sqlmock.New()
@@ -544,7 +544,7 @@ func TestCSVManifestCopy(t *testing.T) {
 		ConfFile: "",
 	}
 	// test with creds and GZIP
-	sql := `COPY "%s"."%s" FROM '%s' WITH %s REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON manifest CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s' DELIMITER AS '|' REMOVEQUOTES TRIMBLANKS EMPTYASNULL ACCEPTANYDATE`
+	sql := `COPY "%s"."%s" FROM '%s' WITH %s REGION '%s' TIMEFORMAT 'auto' TRUNCATECOLUMNS STATUPDATE ON COMPUPDATE ON manifest CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s' DELIMITER AS '|' REMOVEQUOTES ESCAPE TRIMBLANKS EMPTYASNULL ACCEPTANYDATE`
 	execRegex := fmt.Sprintf(sql, schema, table, s3File.GetDataFilename(),
 		"GZIP", region, accessID, secretKey)
 

--- a/s3_to_redshift.go
+++ b/s3_to_redshift.go
@@ -79,22 +79,22 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 	// TRUNCATE for dimension tables, but not fact tables
 	if truncate && targetTable != nil {
 		log.Println("truncating table!")
-		if err = db.Truncate(tx, inputConf.Schema, inputTable.Name); err != nil {
+		if err := db.Truncate(tx, inputConf.Schema, inputTable.Name); err != nil {
 			return fmt.Errorf("err running truncate table: %s", err)
 		}
 	}
 	if targetTable == nil {
-		if err = db.CreateTable(tx, inputTable); err != nil {
+		if err := db.CreateTable(tx, inputTable); err != nil {
 			return fmt.Errorf("err running create table: %s", err)
 		}
 	} else {
 		// To prevent duplicates, clear away any existing data within a certain time range as the data date
 		// (that is, sharing the same data date up to a certain time granularity)
-		if err = db.TruncateInTimeRange(tx, inputConf.Schema, inputTable.Name, inputConf.DataDate, timeGranularity, inputTable.Meta.DataDateColumn); err != nil {
+		if err := db.TruncateInTimeRange(tx, inputConf.Schema, inputTable.Name, inputConf.DataDate, timeGranularity, inputTable.Meta.DataDateColumn); err != nil {
 			return fmt.Errorf("err truncating data for data refresh: %s", err)
 		}
 
-		if err = db.UpdateTable(tx, *targetTable, inputTable); err != nil {
+		if err := db.UpdateTable(tx, *targetTable, inputTable); err != nil {
 			return fmt.Errorf("err running update table: %s", err)
 		}
 	}
@@ -103,11 +103,11 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 	// can't switch on file ending as manifest files b/c
 	// manifest files obscure the underlying file types
 	// instead just pass the delimiter along even if it's null
-	if err = db.Copy(tx, inputConf, delimiter, true, gzip); err != nil {
+	if err := db.Copy(tx, inputConf, delimiter, true, gzip); err != nil {
 		return fmt.Errorf("err running copy: %s", err)
 	}
 
-	if err = tx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("err committing transaction: %s", err)
 	}
 	return nil

--- a/s3_to_redshift.go
+++ b/s3_to_redshift.go
@@ -26,7 +26,7 @@ var (
 	dataDate        = flag.String("date", "", "data date we should process, must be full RFC3339")
 	configFile      = flag.String("config", "", "schema & table config to use in YAML format")
 	gzip            = flag.Bool("gzip", true, "whether target files are gzipped, defaults to true")
-	delimiter       = flag.String("delimiter", "", "delimiter for CSV files, usually pipe character")
+	delimiter       = flag.String("delimiter", "", "delimiter for CSV files, usually pipe character. If empty then JSON will be assumed.")
 	timeGranularity = flag.String("granularity", "day", "how often we expect to append new data")
 	// things which will would strongly suggest launching as a second worker are env vars
 	// also the secrets ... shhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
@@ -68,7 +68,7 @@ func truncateDate(date time.Time, granularity string) time.Time {
 	}
 }
 
-// in a transaction, truncate, create or update, and then copy from the s3 dagta file or manifest
+// in a transaction, truncate, create or update, and then copy from the s3 data file or manifest
 // yell loudly if there is anything different in the target table compared to config (different distkey, etc)
 func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable redshift.Table, targetTable *redshift.Table, truncate, gzip bool, delimiter, timeGranularity string) error {
 	tx, err := db.Begin()

--- a/s3_to_redshift.go
+++ b/s3_to_redshift.go
@@ -99,8 +99,8 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 	}
 
 	// COPY direct into it, ok to do since we're in a transaction
-	if err = db.JSONCopy(tx, inputConf, true, gzip); err != nil {
-		return fmt.Errorf("err running JSON copy: %s", err)
+	if err = db.Copy(tx, inputConf, true, gzip); err != nil {
+		return fmt.Errorf("err running copy: %s", err)
 	}
 
 	if err = tx.Commit(); err != nil {

--- a/s3filepath/s3filepath.go
+++ b/s3filepath/s3filepath.go
@@ -69,21 +69,16 @@ func CreateS3File(pc PathChecker, bucket S3Bucket, schema, table, suppliedConf s
 		confFile = suppliedConf
 	}
 
-	// Try to find manifest or data files in the order of:
-	// 1) manifest file
-	// 2) gzipped json file
-	// 3) json file
-	inputFile := S3File{bucket, schema, table, "auto", "manifest", date, confFile}
-	if pc.FileExists(inputFile.GetDataFilename()) {
-		return &inputFile, nil
-	}
-	inputFile = S3File{bucket, schema, table, "auto", "json.gz", date, confFile}
-	if pc.FileExists(inputFile.GetDataFilename()) {
-		return &inputFile, nil
-	}
-	inputFile = S3File{bucket, schema, table, "auto", "json", date, confFile}
-	if pc.FileExists(inputFile.GetDataFilename()) {
-		return &inputFile, nil
+	// Try to find manifest or data files out of the following patterns, in order
+	// we try to get in order as otherwise
+	for _, suffix := range []string{
+		"manifest", // 1) manifest file
+		"json.gz",  // 2) gzipped json file
+		"json"} {   // 3) json file
+		inputFile := S3File{bucket, schema, table, "auto", suffix, date, confFile}
+		if pc.FileExists(inputFile.GetDataFilename()) {
+			return &inputFile, nil
+		}
 	}
 	return nil, fmt.Errorf("S3 file not found at: bucket: %s schema: %s, table: %s date: %s",
 		bucket.Name, schema, table, formattedDate)

--- a/s3filepath/s3filepath.go
+++ b/s3filepath/s3filepath.go
@@ -75,7 +75,7 @@ func CreateS3File(pc PathChecker, bucket S3Bucket, schema, table, suppliedConf s
 		"json.gz",  // 2) gzipped json file
 		"json",     // 3) json file
 		".gz",      // 4) gzipped csv file (.gz)
-		""} {       // 5) csv file (no suffix :-/)
+		""} {       // 5) csv file (no suffix when UNLOADed :-/)
 		inputFile := S3File{bucket, schema, table, suffix, date, confFile}
 		if pc.FileExists(inputFile.GetDataFilename()) {
 			return &inputFile, nil

--- a/s3filepath/s3filepath.go
+++ b/s3filepath/s3filepath.go
@@ -73,7 +73,9 @@ func CreateS3File(pc PathChecker, bucket S3Bucket, schema, table, suppliedConf s
 	for _, suffix := range []string{
 		"manifest", // 1) manifest file
 		"json.gz",  // 2) gzipped json file
-		"json"} {   // 3) json file
+		"json",     // 3) json file
+		".gz",      // 4) gzipped csv file (.gz)
+		""} {       // 5) csv file (no suffix :-/)
 		inputFile := S3File{bucket, schema, table, suffix, date, confFile}
 		if pc.FileExists(inputFile.GetDataFilename()) {
 			return &inputFile, nil

--- a/s3filepath/s3filepath.go
+++ b/s3filepath/s3filepath.go
@@ -25,13 +25,12 @@ type S3Bucket struct {
 // S3File holds everything needed to run a COPY on the file
 type S3File struct {
 	// info on which file to get
-	Bucket    S3Bucket
-	Schema    string
-	Table     string
-	JSONPaths string
-	Suffix    string
-	DataDate  time.Time
-	ConfFile  string
+	Bucket   S3Bucket
+	Schema   string
+	Table    string
+	Suffix   string
+	DataDate time.Time
+	ConfFile string
 }
 
 // PathChecker is the interface for determining if a path in S3 exists, which allows
@@ -75,7 +74,7 @@ func CreateS3File(pc PathChecker, bucket S3Bucket, schema, table, suppliedConf s
 		"manifest", // 1) manifest file
 		"json.gz",  // 2) gzipped json file
 		"json"} {   // 3) json file
-		inputFile := S3File{bucket, schema, table, "auto", suffix, date, confFile}
+		inputFile := S3File{bucket, schema, table, suffix, date, confFile}
 		if pc.FileExists(inputFile.GetDataFilename()) {
 			return &inputFile, nil
 		}

--- a/s3filepath/s3filepath_test.go
+++ b/s3filepath/s3filepath_test.go
@@ -15,13 +15,12 @@ var (
 func getTestFileWithResults(b, s, t, r, aID, sk, confFile, suf string, date time.Time) S3File {
 	bucket := S3Bucket{b, r, aID, sk}
 	s3File := S3File{
-		Bucket:    bucket,
-		Schema:    s,
-		Table:     t,
-		JSONPaths: "auto",
-		Suffix:    suf,
-		DataDate:  date,
-		ConfFile:  confFile,
+		Bucket:   bucket,
+		Schema:   s,
+		Table:    t,
+		Suffix:   suf,
+		DataDate: date,
+		ConfFile: confFile,
 	}
 	return s3File
 }

--- a/s3filepath/s3filepath_test.go
+++ b/s3filepath/s3filepath_test.go
@@ -40,6 +40,8 @@ func TestCreateS3File(t *testing.T) {
 		bucket, schema, table, expectedDate.Format(time.RFC3339))
 	jsonPath := "s3://b/s_t_2015-11-10T23:00:00Z.json"
 	jsonGzipPath := "s3://b/s_t_2015-11-10T23:00:00Z.json.gz"
+	csvPath := "s3://b/s_t_2015-11-10T23:00:00Z"
+	csvGzipPath := "s3://b/s_t_2015-11-10T23:00:00Z.gz"
 	manifestPath := "s3://b/s_t_2015-11-10T23:00:00Z.manifest"
 
 	// test completely non-existent file
@@ -51,7 +53,9 @@ func TestCreateS3File(t *testing.T) {
 	expFile = getTestFileWithResults(bucket, schema, table, region, accessID, secretKey, expConf, "json.gz", expectedDate)
 	testFiles := map[string]bool{
 		jsonGzipPath: true,
-		jsonPath:     true,
+		jsonPath:     true, // here to make sure it doesn't get confused if there's also a ".json" file
+		csvPath:      true,
+		csvGzipPath:  true,
 	}
 	returnedFile, err = CreateS3File(MockPathChecker{testFiles}, expFile.Bucket, schema, table, "", expectedDate)
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
**Overview:**
We want to support CSV files for our `COPY` commands, specifically because we need to ingest data which was `UPLOAD`ed, and that command only supports CSV

**Testing:**
Tested locally, having trouble testing that the JSON stuff still works however

**Roll Out:**
Simple rollout as it's idempotent
