### PR TITLE
Add back in Region requirement in launch

### DIFF
--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -1,6 +1,7 @@
 run:
   type: docker
 env:
+- AWS_REGION
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
 - REDSHIFT_USER


### PR DESCRIPTION
We want to keep this required in case we need to roll back the change made [here](https://github.com/Clever/s3-to-redshift/pull/70).