### PR TITLE
Add quotes around name for create

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -230,7 +230,7 @@ func getColumnSQL(c ColInfo) string {
 		distKey = "DISTKEY"
 	}
 
-	return fmt.Sprintf(" %s %s %s %s %s %s %s", c.Name, typeMapping[c.Type], defaultVal, notNull, sortKey, primaryKey, distKey)
+	return fmt.Sprintf(" \"%s\" %s %s %s %s %s %s", c.Name, typeMapping[c.Type], defaultVal, notNull, sortKey, primaryKey, distKey)
 }
 
 // CreateTable runs the full create table command in the provided transaction, given a

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -208,9 +208,9 @@ func TestCreateTable(t *testing.T) {
 	//createSQL := `aasdadsa character varying(256) PRIMARY KEY , test5 integer DEFAULT 100 NOT NULL SORTKEY DISTKEY , someww221longtext character varying(10000)`
 	//sql := fmt.Sprintf(`CREATE TABLE "%s"."%s" (%s)`, schema, table, createSQL)
 	regex := `CREATE TABLE ".*".".*".*` +
-		`test1 integer DEFAULT 100 NOT NULL SORTKEY.*` +
-		`DISTKEY.*id character varying\(256\).*PRIMARY KEY.*` +
-		`somelongtext character varying\(65535\).*` // a little awk, but the prepare makes sure this is good
+		`"test1" integer DEFAULT 100 NOT NULL SORTKEY.*` +
+		`DISTKEY.*"id" character varying\(256\).*PRIMARY KEY.*` +
+		`"somelongtext" character varying\(65535\).*` // a little awk, but the prepare makes sure this is good
 
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)


### PR DESCRIPTION
**Overview**

Sometimes a column will have spaces in their name. To handle this we need quotes around the name in the CREATE statement.