### PR TITLE
Bump gearcmd version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -y && \
     apt-get update -y && \
     apt-get install -y curl
 
-RUN curl -L https://github.com/Clever/gearcmd/releases/download/v0.7.0/gearcmd-v0.7.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
+RUN curl -L https://github.com/Clever/gearcmd/releases/download/v0.8.4/gearcmd-v0.8.4-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1
 
 COPY bin/s3-to-redshift /usr/bin/s3-to-redshift
 


### PR DESCRIPTION
**JIRA**: https://clever.atlassian.net/browse/IP-1002 (oncall)

**Overview**: Update `s3-to-redshift` to the latest version of `gearcmd`. This will be useful for `heartbeat` logging, which can notify us when long-running jobs are running so that we can debug live.

**Testing**: See: https://github.com/Clever/gearcmd/pull/50

**Roll Out:**

Remember to revert the .drone.yml change

CC: Assigning you @bstein-clever since Schimmy is busy AFAICT