### PR TITLE
Add clone for elb logs cluster

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,7 @@ publish:
     applications:
     - s3-to-redshift
     - s3-to-redshift-fast
+    - s3-to-redshift-elb-logs
   docker:
     docker_host: $$docker_server
     email: $$docker_email

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,4 @@
 **Testing**:
 
 **Roll Out**:
-- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
+- [ ] Remember to deploy all clones: `s3-to-redshift`, `s3-to-redshift-fast`, and `s3-to-redshift-elb-logs`

--- a/launch/s3-to-redshift-elb-logs.yml
+++ b/launch/s3-to-redshift-elb-logs.yml
@@ -1,0 +1,18 @@
+run:
+  type: docker
+env:
+- AWS_REGION
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+- REDSHIFT_USER
+- REDSHIFT_PASSWORD
+- REDSHIFT_PORT
+- REDSHIFT_HOST
+- REDSHIFT_DB
+- WORKER_NAME
+dependencies:
+- gearmand
+team: eng-ip
+resources:
+  cpu: 0.05
+  max_mem: 0.05


### PR DESCRIPTION
**JIRA**:
none

**Overview**:
the other side of https://github.com/Clever/record-keeper/pull/20

**Testing**:

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast` (and the new clone!)

