### PR TITLE
Route worker name correctly

### DIFF
--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -5,6 +5,6 @@ routes:
     output:
       type: "alerts"
       series: "job.finished"
-      dimensions: [ "function", "payload" ]
+      dimensions: [ "source", "payload" ]
       value: "value"
       stat_type: "gauge"


### PR DESCRIPTION
**JIRA**: Oncall, N/A

**Overview**: Previously we weren't routing the worker name to SignalFx correctly since `function` appears to now be logged as `source` by Kayvee. We want to be able to alert on both payload and worker name!

**Testing**: Verified that the routed logs now contain the worker name.

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
