### PR TITLE
Truncate like we mean it

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -358,9 +358,8 @@ func (r *Redshift) Copy(tx *sql.Tx, f s3filepath.S3File, delimiter string, creds
 }
 
 // Truncate deletes all items from a table, given a transaction, a schema string and a table name
-// you should run vacuum and analyze soon after doing this for performance reasons
 func (r *Redshift) Truncate(tx *sql.Tx, schema, table string) error {
-	truncStmt, err := tx.Prepare(fmt.Sprintf(`DELETE FROM "%s"."%s"`, schema, table))
+	truncStmt, err := tx.Prepare(fmt.Sprintf(`TRUNCATE "%s"."%s"`, schema, table))
 	if err != nil {
 		return err
 	}

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -459,8 +459,8 @@ func TestTruncate(t *testing.T) {
 	mockRedshift := Redshift{db}
 
 	mock.ExpectBegin()
-	mock.ExpectPrepare(fmt.Sprintf(`DELETE FROM "%s"."%s"`, schema, table))
-	mock.ExpectExec(`DELETE FROM ".*".".*"`).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectPrepare(fmt.Sprintf(`TRUNCATE "%s"."%s"`, schema, table))
+	mock.ExpectExec(`TRUNCATE ".*".".*"`).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tx, err := mockRedshift.Begin()


### PR DESCRIPTION
**JIRA**: https://clever.atlassian.net/browse/IPOC-268

**Overview**: Truncate is necessary since it won't require a VACUUM afterwards. (`DELETE FROM` leaves "deleted rows" lying around in Redshift which adversely affects query performance)

**Testing**:

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
