### PR TITLE
Vacuum / analyze after truncating

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,9 +155,8 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 	}
 
 	if truncate {
-		// If we've truncated the table we should run vacuum and analyze to sort the
-		// data, remove the deleted rows, and update the statistics.
-		if err := db.VacuumAnalyze(inputConf.Schema, inputTable.Name); err != nil {
+		// If we've truncated the table we should run vacuum to clear out the old data
+		if err := db.VacuumDelete(inputConf.Schema, inputTable.Name); err != nil {
 			return fmt.Errorf("err vacuuming or analyzing database: %s", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"database/sql"
 	"flag"
 	"fmt"
 	"log"
@@ -210,7 +209,7 @@ func main() {
 
 		// figure out what the current state of the table is to determine if the table is already up to date
 		targetTable, lastTargetData, err := db.GetTableMetadata(inputConf.Schema, inputConf.Table, inputTable.Meta.DataDateColumn)
-		if err != nil && err != sql.ErrNoRows { // ErrNoRows is fine, just means the table doesn't exist
+		if err != nil {
 			fatalIfErr(err, "Error getting existing latest table metadata") // use fatalIfErr to stay the same
 		}
 

--- a/main.go
+++ b/main.go
@@ -153,6 +153,14 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("err committing transaction: %s", err)
 	}
+
+	if truncate {
+		// If we've truncated the table we should run vacuum and analyze to sort the
+		// data, remove the deleted rows, and update the statistics.
+		if err := db.VacuumAnalyze(inputConf.Schema, inputTable.Name); err != nil {
+			return fmt.Errorf("err vacuuming or analyzing database: %s", err)
+		}
+	}
 	return nil
 }
 

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -391,15 +391,11 @@ func (r *Redshift) TruncateInTimeRange(tx *sql.Tx, schema, table string, dataDat
 	return err
 }
 
-// VacuumAnalyze performs VACUUM FULL; ANALYZE on the redshift database. This is useful for
+// VacuumDelete runs a vacuum - delete only command
 // recreating the indices after a database has been modified and updating the query planner.
-func (r *Redshift) VacuumAnalyze(schema, table string) error {
-	if _, err := r.Exec(fmt.Sprintf(`VACUUM %s."%s"`, schema, table)); err != nil {
+func (r *Redshift) VacuumDelete(schema, table string) error {
+	if _, err := r.Exec(fmt.Sprintf(`VACUUM DELETE ONLY %s."%s"`, schema, table)); err != nil {
 		return fmt.Errorf(`error vacuuming %s."%s": %s`, schema, table, err)
-	}
-
-	if _, err := r.Exec(fmt.Sprintf(`ANALYZE %s."%s"`, schema, table)); err != nil {
-		return fmt.Errorf(`error analyzing %s."%s": %s`, schema, table, err)
 	}
 	return nil
 }

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -201,7 +201,10 @@ func (r *Redshift) GetTableMetadata(schema, tableName, dataDateCol string) (*Tab
 	lastDataQuery := fmt.Sprintf(`SELECT "%s" FROM "%s"."%s" ORDER BY "%s" DESC LIMIT 1`,
 		dataDateCol, schema, tableName, dataDateCol)
 	var lastData time.Time
-	if err = r.QueryRow(lastDataQuery).Scan(&lastData); err != nil {
+	err = r.QueryRow(lastDataQuery).Scan(&lastData)
+	if err != nil && err == sql.ErrNoRows {
+		return &retTable, nil, nil
+	} else if err != nil {
 		return nil, nil, fmt.Errorf("issue running query: %s, err: %s", lastDataQuery, err)
 	}
 	return &retTable, &lastData, nil

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -592,13 +592,3 @@ func TestTruncateInTimeRange(t *testing.T) {
 		t.Errorf("there were unfulfilled expections: %s", err)
 	}
 }
-
-func TestVacuumAnalyzeTable(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	assert.NoError(t, err)
-	defer db.Close()
-	mockRedshift := Redshift{db}
-	mock.ExpectExec(`VACUUM FULL`).WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(`ANALYZE`).WillReturnResult(sqlmock.NewResult(0, 0))
-	assert.NoError(t, mockRedshift.VacuumAnalyze())
-}


### PR DESCRIPTION
This PR does two things:
1. Handles an empty table in this worker
2. Runs vacuum / analyze on the table if we truncated it. We could be a bit more aggressive and do these even when we don't truncate the whole table, but I figure it's better to start conservative.

Theoretically after we merge this we could remove some of the redshift-respawn jobs that vacuum tables like mongo.students.

Tested by running locally against the dev cluster.

**JIRA**:

**Overview**:

**Testing**:

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
