### PR TITLE
Alert by schema only

### DIFF
--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -27,12 +27,12 @@ func TestJobFinished(t *testing.T) {
 	}{
 		{
 			rule:       "job-finished",
-			payload:    "--bucket clever-analytics-dev --schema api --tables business_metrics_auth_counts",
+			payload:    "--schema api --tables business_metrics_auth_counts",
 			didSucceed: true,
 		},
 		{
 			rule:       "job-finished",
-			payload:    "--bucket clever-analytics-dev --schema api --tables business_metrics_auth_counts",
+			payload:    "--schema api --tables business_metrics_auth_counts",
 			didSucceed: false,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -212,8 +212,7 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 func main() {
 	flag.Parse()
 
-	payloadForSignalFx = fmt.Sprintf("--schema %s --tables %s --bucket %s --truncate=%t --force=%t --gzip=%t --delimiter %s --granularity %s",
-		*inputSchemaName, *inputTables, *inputBucket, *truncate, *force, *gzip, *delimiter, *timeGranularity)
+	payloadForSignalFx = fmt.Sprintf("--schema %s", *inputSchemaName)
 	defer logger.JobFinishedEvent(payloadForSignalFx, true)
 
 	// verify that timeGranularity is a supported value. for convenience,


### PR DESCRIPTION
**JIRA**: N/A, oncall idea

**Overview**: Our alerting by payload has been broken for ages :/. Alisha had an idea to trim the payloads we send to SignalFx so that they don't include information we don't care about.

Starting with just schema for now, can expand to add more fields as needed.

**Testing**:
- [x] Updated unit test for logger package

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
