### PR TITLE
Add support for streaming payloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,18 @@ PKGS := $(shell go list ./... | grep -v /vendor)
 EXECUTABLE := $(shell basename $(PKG))
 $(eval $(call golang-version-check,1.8))
 
+# variables for testing
+export GEARMAN_ADMIN_PATH ?= x
+export GEARMAN_ADMIN_USER ?= x
+export GEARMAN_ADMIN_PASS ?= x
+export VACUUM_WORKER ?= x
+export REDSHIFT_PASSWORD ?= x
+export REDSHIFT_USER ?= x
+export REDSHIFT_DB ?= x
+export SERVICE_GEARMAN_ADMIN_HTTP_HOST ?= x
+export SERVICE_GEARMAN_ADMIN_HTTP_PORT ?= x
+export SERVICE_GEARMAN_ADMIN_HTTP_PROTO ?= x
+
 all: test build
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ export REDSHIFT_DB ?= x
 export SERVICE_GEARMAN_ADMIN_HTTP_HOST ?= x
 export SERVICE_GEARMAN_ADMIN_HTTP_PORT ?= x
 export SERVICE_GEARMAN_ADMIN_HTTP_PROTO ?= x
+export AWS_REGION ?= x
+export AWS_ACCESS_KEY_ID ?= x
+export AWS_SECRET_ACCESS_KEY ?= x
 
 all: test build
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ This file is accessed via [Pathio](https://github.com/Clever/pathio), so the fil
 #### Using `--truncate`
 Without the `--truncate` option set, `s3-to-redshift` will insert into an existing table but leave any data already remaining in the table (except for the most recent data within the past granularity time range, which will be refreshed as new syncs come in).
 
+Additionally, `s3-to-redshift` will not insert or overwrite for a particular time period thus the worker is idempotent and duplicate data is not a concern.
+
 If you instead are adding snapshot / dimension data to `Redshift`, you should use the `--truncate` option to clear out the existing data before inserting the current "state of the world".
 
 *One caveat:* the `--truncate` option does not also imply `--force`!

--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ This file is accessed via [Pathio](https://github.com/Clever/pathio), so the fil
 
 #### Using `--truncate`
 Without the `--truncate` option set, `s3-to-redshift` will insert into an existing table but leave any data already remaining in the table (except for the most recent data within the past granularity time range, which will be refreshed as new syncs come in).
-Additionally, `s3-to-redshift` will not insert or overwrite for a particular time period thus the worker is idempotent and duplicate data is not a concern.
-This behavior is ideal if you are adding time-series data / fact data to `Redshift`.
 
 If you instead are adding snapshot / dimension data to `Redshift`, you should use the `--truncate` option to clear out the existing data before inserting the current "state of the world".
 
@@ -103,7 +101,9 @@ Also please note that this can cause performance problems if you are not running
 #### Using `--granularity`
 The `--granularity` flag describes how often we expect to append new data to the destination table. For instance, perhaps we would like to track daily school counts in `Redshift`. Therefore, we expect one set of values per day to be stored in this table (and we specify this with `--granularity=day`). Multiple `s3-to-redshift` syncs updating the daily school count can still happen each day, but only the most recent sync data will be stored (as `s3-to-redshift` will simply overwrite the existing school counts for the most recent day). As a result, `s3-to-redshift` refreshes data in the latest time range, while leaving historical data untouched (and modifiable only via `--force`). The width of this time range is specified by `--granularity`.
 
-Currently supported granularities are `hour` and `day`.
+We also support a 'streaming' granularity which means that we don't have a fixed granularity and we can pull data whenever. If the granularity is streaming we only add new data to the table.
+
+Currently supported granularities are `hour`, `day`, `stream`.
 
 ### Example run:
 Assuming that environment variables have been set:

--- a/main.go
+++ b/main.go
@@ -64,16 +64,6 @@ func init() {
 	gearmanAdminPass := env.MustGet("GEARMAN_ADMIN_PASS")
 	gearmanAdminPath := env.MustGet("GEARMAN_ADMIN_PATH")
 	gearmanAdminURL = generateServiceEndpoint(gearmanAdminUser, gearmanAdminPass, gearmanAdminPath)
-
-	dir, err := osext.ExecutableFolder()
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = logger.SetGlobalRouting(path.Join(dir, "kvconfig.yml"))
-	_ = err
-	//if err != nil {
-	// log.Fatal(err)
-	//}
 }
 
 func generateServiceEndpoint(user, pass, path string) string {
@@ -240,6 +230,15 @@ func startEndFromGranularity(t time.Time, granularity string) (time.Time, time.T
 // The worker also uses a column in the data to figure out whether the s3 data is
 // newer than what already exists.
 func main() {
+	dir, err := osext.ExecutableFolder()
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = logger.SetGlobalRouting(path.Join(dir, "kvconfig.yml"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	flag.Parse()
 
 	payloadForSignalFx = fmt.Sprintf("--schema %s", *inputSchemaName)

--- a/main.go
+++ b/main.go
@@ -11,17 +11,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/kardianos/osext"
-	env "github.com/segmentio/go-env"
-
-	"github.com/Clever/discovery-go"
+	discovery "github.com/Clever/discovery-go"
 	"github.com/Clever/s3-to-redshift/logger"
 	redshift "github.com/Clever/s3-to-redshift/redshift"
 	s3filepath "github.com/Clever/s3-to-redshift/s3filepath"
-	"github.com/hashicorp/go-multierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/kardianos/osext"
+	env "github.com/segmentio/go-env"
 )
 
 var (
@@ -152,11 +151,11 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 		var start, end time.Time
 		var err error
 		if timeGranularity == "stream" {
-			start, err = time.Parse(*streamStart, "2006-01-02T15:04:05.000Z")
+			start, err = time.Parse("2006-01-02T15:04:05", *streamStart)
 			if err != nil {
 				return err
 			}
-			end, err = time.Parse(*streamEnd, "2006-01-02T15:04:05.000Z")
+			end, err = time.Parse("2006-01-02T15:04:05", *streamEnd)
 			if err != nil {
 				return err
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeGranularity(t *testing.T) {
+	baseTime := time.Date(2017, 7, 11, 12, 0, 0, 0, time.UTC)
+
+	start, end := startEndFromGranularity(baseTime, "day")
+	assert.Equal(t, start, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, end, time.Date(2017, 7, 12, 0, 0, 0, 0, time.UTC))
+}

--- a/main_test.go
+++ b/main_test.go
@@ -13,4 +13,8 @@ func TestTimeGranularity(t *testing.T) {
 	start, end := startEndFromGranularity(baseTime, "day")
 	assert.Equal(t, start, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 12, 0, 0, 0, 0, time.UTC))
+
+	start, end = startEndFromGranularity(baseTime, "week")
+	assert.Equal(t, start, time.Date(2017, 7, 10, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, end, time.Date(2017, 7, 17, 0, 0, 0, 0, time.UTC))
 }

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/Clever/pathio"
 	multierror "github.com/hashicorp/go-multierror"
@@ -448,7 +448,7 @@ func (r *Redshift) TruncateInTimeRange(tx *sql.Tx, schema, table, dataDateCol st
 	start, end time.Time) error {
 	truncSQL := fmt.Sprintf(`
 		DELETE FROM "%s"."%s"
-		WHERE '%s' >= '%s' AND '%s' < '%s'
+		WHERE "%s" >= '%s' AND "%s" < '%s'
 		`, schema, table, dataDateCol, start.Format("2006-01-02 15:04:05"),
 		dataDateCol, end.Format("2006-01-02 15:04:05"))
 	truncStmt, err := tx.Prepare(truncSQL)

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -366,7 +366,11 @@ func checkColumn(inCol ColInfo, targetCol ColInfo) error {
 		errors = multierror.Append(errors, fmt.Errorf(mismatchedTemplate, inCol.Name, "Name", inCol.Name, targetCol.Name))
 	}
 	if typeMapping[inCol.Type] != targetCol.Type {
-		errors = multierror.Append(errors, fmt.Errorf(mismatchedTemplate, inCol.Name, "Type", typeMapping[inCol.Type], targetCol.Type))
+		if strings.HasPrefix(typeMapping[inCol.Type], "character varying") && strings.HasPrefix(typeMapping[inCol.Type], "character varying") {
+			// If they are both varchars but differing values, we will ignore this
+		} else {
+			errors = multierror.Append(errors, fmt.Errorf(mismatchedTemplate, inCol.Name, "Type", typeMapping[inCol.Type], targetCol.Type))
+		}
 	}
 	if inCol.DefaultVal != targetCol.DefaultVal {
 		errors = multierror.Append(errors, fmt.Errorf(mismatchedTemplate, inCol.Name, "DefaultVal", inCol.DefaultVal, targetCol.DefaultVal))

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -444,11 +444,13 @@ func (r *Redshift) Truncate(tx *sql.Tx, schema, table string) error {
 // TruncateInTimeRange deletes all items within a specific time range - that is,
 // matching `dataDate` when rounded to a certain granularity `timeGranularity`
 // NOTE: this assumes that "time" is a column in the table
-func (r *Redshift) TruncateInTimeRange(tx *sql.Tx, schema, table string, dataDate time.Time, timeGranularity string, dataDateCol string) error {
+func (r *Redshift) TruncateInTimeRange(tx *sql.Tx, schema, table, dataDateCol string,
+	start, end time.Time) error {
 	truncSQL := fmt.Sprintf(`
 		DELETE FROM "%s"."%s"
-		WHERE date_trunc('%s', "%s") = date_trunc('%s', timestamp '%s')
-		`, schema, table, timeGranularity, dataDateCol, timeGranularity, dataDate.Format("2006-01-02 15:04:05"))
+		WHERE '%s' >= '%s' AND '%s' < '%s'
+		`, schema, table, dataDateCol, start.Format("2006-01-02 15:04:05"),
+		dataDateCol, end.Format("2006-01-02 15:04:05"))
 	truncStmt, err := tx.Prepare(truncSQL)
 	if err != nil {
 		return err

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -42,7 +42,11 @@ func TestTableFromConf(t *testing.T) {
 
 	schema, table := "testschema", "testtable"
 	bucket, region, accessID, secretKey := "bucket", "region", "accessID", "secretKey"
-	b := s3filepath.S3Bucket{bucket, region, accessID, secretKey}
+	b := s3filepath.S3Bucket{
+		Name:      bucket,
+		Region:    region,
+		AccessID:  accessID,
+		SecretKey: secretKey}
 
 	matchingTable := Table{
 		Name:    table,
@@ -268,7 +272,11 @@ func TestNoKeyCreateTable(t *testing.T) {
 func TestJSONCopy(t *testing.T) {
 	schema, table := "testschema", "tablename"
 	bucket, region, accessID, secretKey := "bucket", "region", "accessID", "secretKey"
-	b := s3filepath.S3Bucket{bucket, region, accessID, secretKey}
+	b := s3filepath.S3Bucket{
+		Name:      bucket,
+		Region:    region,
+		AccessID:  accessID,
+		SecretKey: secretKey}
 	s3File := s3filepath.S3File{
 		Bucket:   b,
 		Schema:   schema,
@@ -326,7 +334,11 @@ func TestJSONCopy(t *testing.T) {
 func TestJSONManifestCopy(t *testing.T) {
 	schema, table := "testschema", "tablename"
 	bucket, region, accessID, secretKey := "bucket", "region", "accessID", "secretKey"
-	b := s3filepath.S3Bucket{bucket, region, accessID, secretKey}
+	b := s3filepath.S3Bucket{
+		Name:      bucket,
+		Region:    region,
+		AccessID:  accessID,
+		SecretKey: secretKey}
 	s3File := s3filepath.S3File{
 		Bucket:   b,
 		Schema:   schema,
@@ -384,7 +396,11 @@ func TestTruncate(t *testing.T) {
 func TestCSVCopy(t *testing.T) {
 	schema, table := "testschema", "tablename"
 	bucket, region, accessID, secretKey := "bucket", "region", "accessID", "secretKey"
-	b := s3filepath.S3Bucket{bucket, region, accessID, secretKey}
+	b := s3filepath.S3Bucket{
+		Name:      bucket,
+		Region:    region,
+		AccessID:  accessID,
+		SecretKey: secretKey}
 	s3File := s3filepath.S3File{
 		Bucket:   b,
 		Schema:   schema,
@@ -442,7 +458,11 @@ func TestCSVCopy(t *testing.T) {
 func TestCSVManifestCopy(t *testing.T) {
 	schema, table := "testschema", "tablename"
 	bucket, region, accessID, secretKey := "bucket", "region", "accessID", "secretKey"
-	b := s3filepath.S3Bucket{bucket, region, accessID, secretKey}
+	b := s3filepath.S3Bucket{
+		Name:      bucket,
+		Region:    region,
+		AccessID:  accessID,
+		SecretKey: secretKey}
 	s3File := s3filepath.S3File{
 		Bucket:   b,
 		Schema:   schema,
@@ -468,32 +488,6 @@ func TestCSVManifestCopy(t *testing.T) {
 	tx, err := mockRedshift.Begin()
 	assert.NoError(t, err)
 	assert.NoError(t, mockRedshift.Copy(tx, s3File, "|", true, true))
-	assert.NoError(t, tx.Commit())
-
-	if err = mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
-	}
-}
-
-func TestTruncateInTimeRange(t *testing.T) {
-	schema, table := "test_schema", "test_table"
-	granularity := "hour"
-	timeColumn := "time"
-	dateString := "2016-04-21 20:29:05"
-	dataDate, _ := time.Parse("2006-01-02 15:04:05", dateString)
-	db, mock, err := sqlmock.New()
-	assert.NoError(t, err)
-	defer db.Close()
-	mockRedshift := Redshift{db}
-
-	mock.ExpectBegin()
-	mock.ExpectPrepare(fmt.Sprintf(`DELETE FROM "%s"."%s" WHERE date_trunc('%s', "time") = date_trunc('%s', timestamp '%s')`, schema, table, granularity, granularity, dateString))
-	mock.ExpectExec(`DELETE FROM ".*".".*" WHERE date_trunc\('.*', "time"\) = date_trunc\('.*', timestamp '.*'\)`).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectCommit()
-
-	tx, err := mockRedshift.Begin()
-	assert.NoError(t, err)
-	assert.NoError(t, mockRedshift.TruncateInTimeRange(tx, schema, table, dataDate, granularity, timeColumn))
 	assert.NoError(t, tx.Commit())
 
 	if err = mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
Now that we support granularity = 'stream' (see https://github.com/Clever/record-keeper/pull/28) we need to support making that idempotent. That means adding start / end dates instead of just granularities to the payload. That way we can delete all the day in the time range before adding the new rows.

**JIRA**:

**Overview**:

**Testing**:

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
