### PR TITLE
Allow ignore of sortkey and distkey

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 			return fmt.Errorf("err truncating data for data refresh: %s", err)
 		}
 
-		if err := db.UpdateTable(tx, *targetTable, inputTable); err != nil {
+		if err := db.UpdateTable(tx, inputTable, *targetTable); err != nil {
 			return fmt.Errorf("err running update table: %s", err)
 		}
 	}

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -377,10 +377,11 @@ func checkColumn(inCol ColInfo, targetCol ColInfo) error {
 	if inCol.PrimaryKey != targetCol.PrimaryKey {
 		errors = multierror.Append(errors, fmt.Errorf(mismatchedTemplate, inCol.Name, "PrimaryKey", inCol.PrimaryKey, targetCol.PrimaryKey))
 	}
-	if inCol.DistKey != targetCol.DistKey {
+	// for distkey & sortkey it's ok if the source doesn't have them, but they should at least not disagree
+	if inCol.DistKey && inCol.DistKey != targetCol.DistKey {
 		errors = multierror.Append(errors, fmt.Errorf(mismatchedTemplate, inCol.Name, "DistKey", inCol.DistKey, targetCol.DistKey))
 	}
-	if inCol.SortOrdinal != targetCol.SortOrdinal {
+	if inCol.SortOrdinal != 0 && inCol.SortOrdinal != targetCol.SortOrdinal {
 		errors = multierror.Append(errors, fmt.Errorf(mismatchedTemplate, inCol.Name, "SortOrdinal", inCol.SortOrdinal, targetCol.SortOrdinal))
 	}
 	return errors

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -590,6 +590,23 @@ func TestCheckSchemasDiffs(t *testing.T) {
 	assert.Equal(t, 5, len(err.(*multierror.Error).Errors), fmt.Sprintf("Errors: %s", err))
 }
 
+func TestCheckSchemasDifferingSortkey(t *testing.T) {
+	// Do a different sortkey
+	t1 := Table{Columns: []ColInfo{
+		ColInfo{Name: "DateColumn", Type: "timestamp"},
+		ColInfo{Name: "IntColumn", Type: "int", SortOrdinal: 1},
+		ColInfo{Name: "IntColumn2", Type: "int"},
+	}}
+	t2 := Table{Columns: []ColInfo{
+		ColInfo{Name: "DateColumn", Type: "timestamp without time zone"},
+		ColInfo{Name: "IntColumn", Type: "integer"},
+		ColInfo{Name: "IntColumn2", Type: "integer", SortOrdinal: 1},
+	}}
+	columnOps, err := checkSchemas(t2, t1)
+	assert.Equal(t, 0, len(columnOps))
+	assert.Equal(t, 1, len(err.(*multierror.Error).Errors), fmt.Sprintf("Errors: %s", err))
+}
+
 func TestReorder(t *testing.T) {
 	t1 := Table{Columns: []ColInfo{
 		ColInfo{Name: "IntColumn", Type: "integer"},


### PR DESCRIPTION
**JIRA**:
https://clever.atlassian.net/browse/IP-1532

**Overview**:
If you want to pull from a view and materialize into a table, for instance, you won't get a sort or distkey. This change enforces creating a table with a sort & distkey, and also relaxes the constraint that the destination table must have the same sortkey & distkey _as long as the source table has no sort or distkey_