### PR TITLE
Escape quotes in argument to redshift-vacuum

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,7 +195,10 @@ func runCopy(db *redshift.Redshift, inputConf s3filepath.S3File, inputTable reds
 			log.Println("Submitting job to Gearman admin")
 			client := &http.Client{}
 			endpoint := gearmanAdminURL + fmt.Sprintf("/%s", vacuumWorker)
-			payload := fmt.Sprintf(`--delete %s."%s"`, inputConf.Schema, inputTable.Name)
+
+			// N.B. We need to pass backslashes to escape the quotation marks as required
+			// by Golang's os.Args for command line arguments
+			payload := fmt.Sprintf(`--delete %s.\"%s\"`, inputConf.Schema, inputTable.Name)
 			req, err := http.NewRequest("POST", endpoint, bytes.NewReader([]byte(payload)))
 			if err != nil {
 				log.Fatalf("Error creating new request: %s", err)


### PR DESCRIPTION
**JIRA**: N/A, oncall.

**Overview**: Turns out we weren't actually surrounding our table names with double quotes after all - Golang's os.Args requires double quotes to be escaped. (A simple way to verify this is to write a dummy program and test out how it parses your string arguments by using `flags.Parse()` or printing out `os.Args[1:]`).

**Testing**: Discovered as part of https://github.com/Clever/redshift-vacuum/pull/8

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
