### PR TITLE
IP-1556: Add support for EOD in PST

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See the Makefile for a complete list of parameters you can use for testing.
 - `config`: override of the usual auto-discovery of the config
 - `delimiter`: required to use CSV files, what the file is delimited in (likely use the '|' pipe character as that is AWS' default). If `""` then JSON copy is assumed
 - `granularity`: how often we expect to append new data for each table (i.e. daily, or hourly buckets)
+- `timezone`: specifies what timezone the target data is in (i.e. 'America/Los_Angeles'). Must be in the IANA Time Zone database.
 
 #### Note on general usage:
 

--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func main() {
 			(truncateDate(*lastTargetData, *timeGranularity)).After(truncateDate(parsedDate, *timeGranularity)) {
 			if *force == false {
 				log.Printf("Recent data already exists in db: %s", *lastTargetData)
-				return
+				continue
 			}
 			log.Printf("Forcing update of inputTable: %s", inputConf.Table)
 		}

--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ func startEndFromGranularity(t time.Time, granularity string) (time.Time, time.T
 	if granularity == "day" {
 		duration = time.Hour * 24
 	} else {
-		duration = time.Hour * 24 * 7
+		duration = time.Hour
 	}
 
 	start := t.UTC().Truncate(duration)

--- a/main_test.go
+++ b/main_test.go
@@ -18,3 +18,28 @@ func TestTimeGranularity(t *testing.T) {
 	assert.Equal(t, start, time.Date(2017, 7, 11, 12, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 11, 13, 0, 0, 0, time.UTC))
 }
+
+func TestIsInputDataStale(t *testing.T) {
+	locationUTC, _ := time.LoadLocation("UTC")
+	inputDataDate, _ := time.Parse(time.RFC3339, "2017-08-15T14:00:00Z")
+	targetDataDate, _ := time.Parse(time.RFC3339, "2017-08-15T21:00:00Z")
+
+	assert.Equal(t, false, isInputDataStale(inputDataDate, &targetDataDate, "day", locationUTC))
+	assert.Equal(t, true, isInputDataStale(inputDataDate, &targetDataDate, "hour", locationUTC))
+	assert.Equal(t, false, isInputDataStale(inputDataDate, nil, "hour", locationUTC))
+
+	// Simulate Redshift timestamp without time zones that is parsed as UTC but is actually PT
+	locationPT, _ := time.LoadLocation("America/Los_Angeles")
+	targetDataDatePT, _ := time.Parse(time.RFC3339, "2017-08-15T14:00:00Z")
+	inputDataDateUTC, _ := time.Parse(time.RFC3339, "2017-08-15T14:00:00Z")
+
+	assert.Equal(t, false, isInputDataStale(inputDataDateUTC, &targetDataDatePT, "hour", locationUTC))
+	assert.Equal(t, true, isInputDataStale(inputDataDateUTC, &targetDataDatePT, "hour", locationPT))
+
+	// Test Redshift timestamp without time zones where UTC and PT are on different days
+	targetDataDatePT, _ = time.Parse(time.RFC3339, "2017-08-15T23:00:00Z")
+	inputDataDateUTC, _ = time.Parse(time.RFC3339, "2017-08-15T14:00:00Z")
+
+	assert.Equal(t, false, isInputDataStale(inputDataDateUTC, &targetDataDatePT, "day", locationUTC))
+	assert.Equal(t, true, isInputDataStale(inputDataDateUTC, &targetDataDatePT, "day", locationPT))
+}

--- a/main_test.go
+++ b/main_test.go
@@ -10,22 +10,22 @@ import (
 func TestTimeGranularity(t *testing.T) {
 	baseTime := time.Date(2017, 7, 11, 12, 9, 0, 0, time.UTC)
 
-	start, end := startEndFromGranularity(baseTime, "day", false)
+	start, end := startEndFromGranularity(baseTime, "day", "UTC")
 	assert.Equal(t, start, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 12, 0, 0, 0, 0, time.UTC))
 
-	start, end = startEndFromGranularity(baseTime, "hour", false)
+	start, end = startEndFromGranularity(baseTime, "hour", "UTC")
 	assert.Equal(t, start, time.Date(2017, 7, 11, 12, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 11, 13, 0, 0, 0, time.UTC))
 
 	// Simulate timestamps that cross timezones in PT vs UTC
 	baseTime = time.Date(2017, 7, 11, 4, 0, 0, 0, time.UTC)
 
-	start, end = startEndFromGranularity(baseTime, "day", false)
+	start, end = startEndFromGranularity(baseTime, "day", "UTC")
 	assert.Equal(t, start, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 12, 0, 0, 0, 0, time.UTC))
 
-	start, end = startEndFromGranularity(baseTime, "day", true)
+	start, end = startEndFromGranularity(baseTime, "day", "America/Los_Angeles")
 	assert.Equal(t, start, time.Date(2017, 7, 10, 0, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -10,13 +10,24 @@ import (
 func TestTimeGranularity(t *testing.T) {
 	baseTime := time.Date(2017, 7, 11, 12, 9, 0, 0, time.UTC)
 
-	start, end := startEndFromGranularity(baseTime, "day")
+	start, end := startEndFromGranularity(baseTime, "day", false)
 	assert.Equal(t, start, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 12, 0, 0, 0, 0, time.UTC))
 
-	start, end = startEndFromGranularity(baseTime, "hour")
+	start, end = startEndFromGranularity(baseTime, "hour", false)
 	assert.Equal(t, start, time.Date(2017, 7, 11, 12, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 11, 13, 0, 0, 0, time.UTC))
+
+	// Simulate timestamps that cross timezones in PT vs UTC
+	baseTime = time.Date(2017, 7, 11, 4, 0, 0, 0, time.UTC)
+
+	start, end = startEndFromGranularity(baseTime, "day", false)
+	assert.Equal(t, start, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, end, time.Date(2017, 7, 12, 0, 0, 0, 0, time.UTC))
+
+	start, end = startEndFromGranularity(baseTime, "day", true)
+	assert.Equal(t, start, time.Date(2017, 7, 10, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, end, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
 }
 
 func TestIsInputDataStale(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestTimeGranularity(t *testing.T) {
-	baseTime := time.Date(2017, 7, 11, 12, 0, 0, 0, time.UTC)
+	baseTime := time.Date(2017, 7, 11, 12, 9, 0, 0, time.UTC)
 
 	start, end := startEndFromGranularity(baseTime, "day")
 	assert.Equal(t, start, time.Date(2017, 7, 11, 0, 0, 0, 0, time.UTC))
 	assert.Equal(t, end, time.Date(2017, 7, 12, 0, 0, 0, 0, time.UTC))
 
-	start, end = startEndFromGranularity(baseTime, "week")
-	assert.Equal(t, start, time.Date(2017, 7, 10, 0, 0, 0, 0, time.UTC))
-	assert.Equal(t, end, time.Date(2017, 7, 17, 0, 0, 0, 0, time.UTC))
+	start, end = startEndFromGranularity(baseTime, "hour")
+	assert.Equal(t, start, time.Date(2017, 7, 11, 12, 0, 0, 0, time.UTC))
+	assert.Equal(t, end, time.Date(2017, 7, 11, 13, 0, 0, 0, time.UTC))
 }


### PR DESCRIPTION
Please view commit by commit

**JIRA**: https://clever.atlassian.net/browse/IP-1551

**Overview**: Extends s3-to-redshift to allow treating Redshift timestamps (without timezone) as PST timestamps. This ultimately allows us to implement EOD as midnight PST for historical tables by simply changing the data date column to `_record_timestamp_in_pst` for non-streaming `record-keeper` jobs (to be implemented).

**Testing**:
- [x] Wrote tests for new functionality
- [ ] Test in staging

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
