### PR TITLE
Increase timeout for student_app_connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY bin/s3-to-redshift /usr/bin/s3-to-redshift
 CMD exec gearcmd \
   --name ${WORKER_NAME} \
   --cmd s3-to-redshift \
-  --cmdtimeout 30m \
+  --cmdtimeout 120m \
   --retry 1 \
   --warningLength 20


### PR DESCRIPTION
Now that we want to pull user app connections from mongo-to-s3 we have to increase this timeout since it's timing out

**JIRA**:

**Overview**:

**Testing**:

**Roll Out**:
- [ ] Remember to deploy both `s3-to-redshift` and `s3-to-redshift-fast`
