### PR TITLE
Removed --warningLength gearcmd parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,4 @@ CMD exec gearcmd \
   --name ${WORKER_NAME} \
   --cmd s3-to-redshift \
   --cmdtimeout 120m \
-  --retry 1 \
-  --warningLength 20
+  --retry 1


### PR DESCRIPTION
This parameter no longer does anything.  Warnings are trimmed to three by gearman-admin:
https://github.com/Clever/gearman-admin/blob/03f2995bc381f0fd5452ec840d5bf2f2ebf7db78/lib/mongodb.js#L63

Removed in an effort to migrate off of gearman: https://docs.google.com/document/d/1bqMTEfHXXqFMu-kFftS3hLZoqW3FPTUq2FzcU02BO38/edit
