### PR TITLE
Change redshift-vacuum command: delete -> analyze

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func runCopy(
 			// N.B. We need to pass backslashes to escape the quotation marks as required
 			// by Golang's os.Args for command line arguments
 			payload, err := json.Marshal(map[string]string{
-				"delete": inputConf.Schema + `."` + inputTable.Name + `"`,
+				"analyze": inputConf.Schema + `."` + inputTable.Name + `"`,
 			})
 			if err != nil {
 				log.Fatalf("Error creating new payload: %s", err)


### PR DESCRIPTION
This is part of a series of Redshift cluster health updates

**Overview**:
Since we essentially do a full table replacement we should do a full vacuum and analyze since we don't have guarantees about inserting in sorted order

**Testing**:
🔢 

**Roll Out**:
- [x] This repo will auto deploy after you merge. To do a manual deploy, use ark start -e production s3-to-redshift or ark start -e production s3-to-redshift-fast


