### PR TITLE
Handle OS Signals Better

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,16 +23,6 @@
   revision = "84d549efdf0e2928c2be08bdcc3a1b0cf8ef2f45"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/Clever/s3-to-redshift"
-  packages = [
-    "logger",
-    "redshift",
-    "s3filepath"
-  ]
-  revision = "a4e0a4023e0b633483fe5dd3653f9e5aecd7037a"
-
-[[projects]]
   name = "github.com/DATA-DOG/go-sqlmock"
   packages = ["."]
   revision = "081a694b0af16f86d406ac2832433a98a6fa625a"
@@ -158,6 +148,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d0615635406790960754d052f9f7506770695d7fbbcc1b33dc66156a539a235e"
+  inputs-digest = "45b9a9fdaa3a45a09a06ff4ac5d27c815a2e813ce0831daa12d23983d2255db7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -1,6 +1,7 @@
 package redshift
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -16,6 +17,10 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	multierror "github.com/hashicorp/go-multierror"
+)
+
+var (
+	textCtx = context.Background()
 )
 
 // helper for TestTableFromConf - marshals the table into a file
@@ -38,7 +43,7 @@ func getTempConfFromTable(name string, table Table) (string, error) {
 }
 
 func TestTableFromConf(t *testing.T) {
-	db := Redshift{nil}
+	db := Redshift{nil, textCtx}
 
 	schema, table := "testschema", "testtable"
 	bucket, region, redshiftRoleARN := "bucket", "region", "redshiftRoleARN"
@@ -131,7 +136,7 @@ func TestGetTableMetadata(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	// test normal operation
 	//   - test existence of table
@@ -219,7 +224,7 @@ func TestCreateTable(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	mock.ExpectPrepare("This needs to be here, but not evaluated")
@@ -252,7 +257,7 @@ func TestNoKeyCreateTable(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 
@@ -291,7 +296,7 @@ func TestJSONCopy(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
@@ -313,7 +318,7 @@ func TestJSONCopy(t *testing.T) {
 	db, mock, err = sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift = Redshift{db}
+	mockRedshift = Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
@@ -352,7 +357,7 @@ func TestJSONManifestCopy(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
@@ -373,7 +378,7 @@ func TestTruncate(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	mock.ExpectPrepare(fmt.Sprintf(`DELETE FROM "%s"."%s"`, schema, table))
@@ -413,7 +418,7 @@ func TestCSVCopy(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
@@ -435,7 +440,7 @@ func TestCSVCopy(t *testing.T) {
 	db, mock, err = sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift = Redshift{db}
+	mockRedshift = Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
@@ -474,7 +479,7 @@ func TestCSVManifestCopy(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	mock.ExpectExec(execRegex).WithArgs().WillReturnResult(sqlmock.NewResult(0, 0))
@@ -508,7 +513,7 @@ func TestUpdateTable(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
-	mockRedshift := Redshift{db}
+	mockRedshift := Redshift{db, textCtx}
 
 	mock.ExpectBegin()
 	for _, updateSQL := range []string{


### PR DESCRIPTION
**JIRA**:
https://clever.atlassian.net/browse/IPOC-738

**Overview**:
Similar to: https://github.com/Clever/redshift-vacuum/pull/19.

Let's make sure to clean up in flight queries, etc in case of a clean exit

Note: updating the datadog `sqlmock` makes this entire thing explode 👎. We might want to revisit this in the future if we have bandwidth

**Testing**:
Updated them 👍 

**Roll Out**:
- [x] This repo will auto deploy after you merge. To do a manual deploy, use ark start -e production s3-to-redshift or ark start -e production s3-to-redshift-fast


