### PR TITLE
Print payload for redshift-to-postgres on supported tables

### DIFF
--- a/main.go
+++ b/main.go
@@ -322,13 +322,7 @@ func main() {
 
 	// we'll print out a payload if this job is related to SAC workflow
 	var payloadForSACWorkflow []byte
-	if flags.InputTables == "school_app_connections" {
-		payloadForSACWorkflow, err = json.Marshal(map[string]interface{}{
-			"schema":      "managed",
-			"input":       "paid_active_school_app_connection_vw",
-			"granularity": flags.TimeGranularity,
-		})
-	} else if flags.InputTables == "managed_paid_active_school_app_connection_vw_day" {
+	if flags.InputTables == "managed_paid_active_school_app_connection_vw_day" {
 		payloadForSACWorkflow, err = json.Marshal(map[string]interface{}{
 			"dest": "consolidated_school_app_connections_count_by_day_vw",
 			"src":  "historical_managed.consolidated_school_app_connections_count_by_day_vw",


### PR DESCRIPTION
**JIRA**:
https://clever.atlassian.net/browse/IP-2009

**Overview**:
Some `redshift-to-postgres` jobs may be part of a workflow and need some output printed to initiate the next job. Adds logic to determine the right payload to print based on the input table.

**Testing**:
Check that unsupported tables do not output the payload
https://clever-dev--hubble.int.clever.com/s3-to-redshift:master/workflows/w/07cd5097-4a6d-4c54-a2ff-9cba670a58da/jobs

**Roll Out**:
- [ ] This repo will auto deploy after you merge. To do a manual deploy, use ark start -e production s3-to-redshift or ark start -e production s3-to-redshift-fast


