### PR TITLE
Removed default bucket value and made input required

### DIFF
--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ func startEndFromGranularity(t time.Time, granularity string, targetTimezone str
 type payload struct {
 	InputSchemaName string `config:"schema"`
 	InputTables     string `config:"tables"`
-	InputBucket     string `config:"bucket"`
+	InputBucket     string `config:"bucket,required"`
 	Truncate        bool   `config:"truncate"`
 	Force           bool   `config:"force"`
 	DataDate        string `config:"date,required"`
@@ -299,7 +299,7 @@ func main() {
 	flags := payload{ // Specifying defaults:
 		InputSchemaName: "mongo",
 		InputTables:     "",
-		InputBucket:     "metrics",
+		InputBucket:     "",
 		Truncate:        false,
 		Force:           false,
 		DataDate:        "",


### PR DESCRIPTION
**Overview**:

I don't think this bucket that was set as the default actually exists. If you don't specify a bucket, it throws an error because it is unable to determine the region for it. By making it required, it will instead error because of that.

**Testing**: 💯 

**Roll Out**:
- [ ] This repo will auto deploy after you merge. To do a manual deploy, use ark start -e production s3-to-redshift or ark start -e production s3-to-redshift-fast


