### PR TITLE
Remove call to redshift-vacuum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,9 @@ SFNCLI_VERSION := latest
 $(eval $(call golang-version-check,1.10))
 
 # variables for testing
-export GEARMAN_ADMIN_PATH ?= x
-export GEARMAN_ADMIN_USER ?= x
-export GEARMAN_ADMIN_PASS ?= x
-export VACUUM_WORKER ?= x
 export REDSHIFT_PASSWORD ?= x
 export REDSHIFT_USER ?= x
 export REDSHIFT_DB ?= x
-export SERVICE_GEARMAN_ADMIN_HTTP_HOST ?= x
-export SERVICE_GEARMAN_ADMIN_HTTP_PORT ?= x
-export SERVICE_GEARMAN_ADMIN_HTTP_PROTO ?= x
 export AWS_REGION ?= x
 export REDSHIFT_ROLE_ARN ?= x
 

--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -8,7 +8,6 @@ env:
 - REDSHIFT_HOST
 - REDSHIFT_ROLE_ARN
 - REDSHIFT_DB
-- WORKER_NAME
 team: eng-ip
 resources:
   cpu: 0.05

--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -2,20 +2,13 @@ run:
   type: docker
 env:
 - AWS_REGION
-- GEARMAN_ADMIN_USER
-- GEARMAN_ADMIN_PASS
-- GEARMAN_ADMIN_PATH
 - REDSHIFT_USER
 - REDSHIFT_PASSWORD
 - REDSHIFT_PORT
 - REDSHIFT_HOST
 - REDSHIFT_ROLE_ARN
 - REDSHIFT_DB
-- VACUUM_WORKER
 - WORKER_NAME
-dependencies:
-- gearmand
-- gearman-admin
 team: eng-ip
 resources:
   cpu: 0.05

--- a/main.go
+++ b/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"os/signal"
 	"path"
@@ -15,7 +12,6 @@ import (
 	"time"
 
 	"github.com/Clever/analytics-util/analyticspipeline"
-	discovery "github.com/Clever/discovery-go"
 	"github.com/Clever/s3-to-redshift/logger"
 	redshift "github.com/Clever/s3-to-redshift/redshift"
 	s3filepath "github.com/Clever/s3-to-redshift/s3filepath"
@@ -37,7 +33,6 @@ var (
 	user            = env.MustGet("REDSHIFT_USER")
 	pwd             = env.MustGet("REDSHIFT_PASSWORD")
 	redshiftRoleARN = env.MustGet("REDSHIFT_ROLE_ARN")
-	vacuumWorker    = env.MustGet("VACUUM_WORKER")
 
 	// payloadForSignalFx holds a subset of the job payload that
 	// we want to alert on as a dimension in SignalFx.
@@ -45,29 +40,7 @@ var (
 	// on job parameters - schema but not date, for instance, since
 	// logging the date would overwhelm SignalFx
 	payloadForSignalFx string
-
-	gearmanAdminURL string
 )
-
-func init() {
-	gearmanAdminUser := env.MustGet("GEARMAN_ADMIN_USER")
-	gearmanAdminPass := env.MustGet("GEARMAN_ADMIN_PASS")
-	gearmanAdminPath := env.MustGet("GEARMAN_ADMIN_PATH")
-	gearmanAdminURL = generateServiceEndpoint(gearmanAdminUser, gearmanAdminPass, gearmanAdminPath)
-}
-
-func generateServiceEndpoint(user, pass, path string) string {
-	hostPort, err := discovery.HostPort("gearman-admin", "http")
-	if err != nil {
-		log.Fatal(err)
-	}
-	proto, err := discovery.Proto("gearman-admin", "http")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return fmt.Sprintf("%s://%s:%s@%s%s", proto, user, pass, hostPort, path)
-}
 
 func fatalIfErr(err error, msg string) {
 	if err != nil {
@@ -205,37 +178,6 @@ func runCopy(
 		return fmt.Errorf("err committing transaction: %s", err)
 	}
 
-	if truncate {
-		// If we've truncated the table we should run vacuum to clear out the old data
-		// Only one vacuum can be run at a time, so we're going to throw this over the wall to
-		// redshift-vacuum and use gearman-admin as a queueing service.
-		if len(gearmanAdminURL) == 0 {
-			log.Fatalf("Unable to post vacuum job to %s", vacuumWorker)
-		} else {
-			log.Println("Submitting job to Gearman admin")
-
-			// N.B. We need to pass backslashes to escape the quotation marks as required
-			// by Golang's os.Args for command line arguments
-			payload, err := json.Marshal(map[string]string{
-				"analyze": inputConf.Schema + `."` + inputTable.Name + `"`,
-			})
-			if err != nil {
-				log.Fatalf("Error creating new payload: %s", err)
-			}
-
-			client := &http.Client{}
-			endpoint := gearmanAdminURL + fmt.Sprintf("/%s", vacuumWorker)
-			req, err := http.NewRequest("POST", endpoint, bytes.NewReader(payload))
-			if err != nil {
-				log.Fatalf("Error creating new request: %s", err)
-			}
-			req.Header.Add("Content-Type", "text/plain")
-			_, err = client.Do(req)
-			if err != nil {
-				log.Fatalf("Error submitting job: %s", err)
-			}
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
Redshift has introduced a lot of features to automate vacuum processes.
We don't need to explicitly run vacuum full's all the time

https://aws.amazon.com/about-aws/whats-new/2018/12/amazon-redshift-automatic-vacuum/
https://aws.amazon.com/about-aws/whats-new/2019/01/amazon-redshift-auto-analyze/

We also get to remove gearman since we don't need it anymore!

**Roll Out:**

No other changes required. I checked against `go/wfsearch` with:
```
Workflow.workflowDefinition.name:"redshift-vacuum:master" AND NOT Workflow.input:*mongo*
```
There is nothing missing in our current cron job definitions