### PR TITLE
Updated autoscaling to active-percent instead of cpu

### DIFF
--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -29,7 +29,7 @@ aws:
     read:
       - long-term-metrics 
 autoscaling:
-  metric: cpu
-  metric_target: 50
+  metric: active-percent
+  metric_target: 90
   min_count: 2
   max_count: 4


### PR DESCRIPTION
**JIRA**: No ticket

**Overview**: This worker is always just stuck at 2 because it's not CPU intensive. We should autoscale depending on the business. Right now it's running a pretty much permanent backlog.

**Testing**: 💯 

**Roll Out**:
- [ ] This repo will auto deploy after you merge. To do a manual deploy, use ark start -e production s3-to-redshift or ark start -e production s3-to-redshift-fast


