### PR TITLE
Revert "Updated autoscaling to active-percent instead of cpu"

### DIFF
--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -29,7 +29,7 @@ aws:
     read:
       - long-term-metrics 
 autoscaling:
-  metric: active-percent
-  metric_target: 90
+  metric: cpu
+  metric_target: 50
   min_count: 2
   max_count: 4


### PR DESCRIPTION
Reverts Clever/s3-to-redshift#137

This ended up not being able to deploy for some reason. Reverting to avoid alerts while infra helps me.

![screen shot 2019-02-19 at 5 30 19 pm](https://user-images.githubusercontent.com/29740422/53063570-69aad000-3479-11e9-95da-62bbffce17e2.png)
