### PR TITLE
Use max query and reduced range scan for more optimized last-value searches.

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -246,7 +246,7 @@ func (r *Redshift) maxTime(fullName, dataDateCol string, rangeLimit rangeQuery) 
 	// SQL Optimization: Redshift doesn't do proper optimizations on max for sort keys, so to reduce our
 	// efficiency, we'll add a where clause to reduce our query area.
 	if rangeLimit != rangeAll {
-		lastDataQuery += fmt.Sprintf(` WHERE time > DATEADD('%s'::text, -1, GETDATE())`, rangeQueryString(rangeLimit))
+		lastDataQuery += fmt.Sprintf(` WHERE time > GETDATE() - INTERVAL '1 %s'`, rangeQueryString(rangeLimit))
 	}
 
 	var lastData pq.NullTime

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -160,7 +160,7 @@ func TestGetTableMetadata(t *testing.T) {
 	mock.ExpectQuery(colInfoRegex).WithArgs().WillReturnRows(colInfoRows)
 	// last data
 	// This is a regex, so we have to escape parentheses.
-	dateRegex := fmt.Sprintf(`SELECT MAX\("%s"\) FROM "%s"."%s" WHERE time > DATEADD\('DAY'::text, -1, GETDATE\(\)\)`, dataDateCol, schema, table)
+	dateRegex := fmt.Sprintf(`SELECT MAX\("%s"\) FROM "%s"."%s" WHERE time > GETDATE\(\) - INTERVAL '1 DAY'`, dataDateCol, schema, table)
 	dateRows := sqlmock.NewRows([]string{"date"})
 	dateRows.AddRow(expectedDate)
 	mock.ExpectQuery(dateRegex).WithArgs().WillReturnRows(dateRows)

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -159,7 +159,8 @@ func TestGetTableMetadata(t *testing.T) {
 	colInfoRows.AddRow("foo", "integer", 5, false, false, false, 0)
 	mock.ExpectQuery(colInfoRegex).WithArgs().WillReturnRows(colInfoRows)
 	// last data
-	dateRegex := fmt.Sprintf(`SELECT "%s" FROM "%s"."%s" ORDER BY "%s" DESC LIMIT 1`, dataDateCol, schema, table, dataDateCol)
+	// This is a regex, so we have to escape parentheses.
+	dateRegex := fmt.Sprintf(`SELECT MAX\("%s"\) FROM "%s"."%s" WHERE time > DATEADD\('DAY'::text, -1, GETDATE\(\)\)`, dataDateCol, schema, table)
 	dateRows := sqlmock.NewRows([]string{"date"})
 	dateRows.AddRow(expectedDate)
 	mock.ExpectQuery(dateRegex).WithArgs().WillReturnRows(dateRows)


### PR DESCRIPTION
N.B. I changed the order of checks here, and did a few tests locally, so I'm pretty sure about the various error cases, but it's worth double checking those flows with a second pair of eyes.


It turns out that Redshift doesn't have good optimizations for queries of the form:
`select max(time) from <table>` when `time` is the sort key for the table, as the min/max-chunks on blocks are only used for range reductions, and this query is otherwise a full-table scan. :(
By adding a where clause like so:
`select max(time) from <table> where time > <1 day ago>`
we can get significant performance because we're looking over a smaller range.

Because it's not guaranteed that we always have results in a specific time range (failed jobs, infrequent firehose logs, etc.) we do multiple passes on increasingly larger time ranges until we get a hit.
In worst-case, we default to the entire table scan again, which is no worse than before.

I did confirm that querying for values that are out of range is extremely fast:
```
prod=#  select time from historical.managed_login_facts_vw_stream where time > '2020-05-01' order by time desc limit 1;
 time 
------
(0 rows)

Time: 30.998 ms
prod=#  select time from historical.managed_login_facts_vw_stream where time > '2020-05-01' order by time desc limit 1;
 time 
------
(0 rows)

Time: 386.647 ms
```
So even in this worst-case, we shouldn't be affecting overall runtime significantly.
