### PR TITLE
Gearmand is dead - remove the dependency, or deploys break.

### DIFF
--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -14,7 +14,6 @@ env:
 - VACUUM_WORKER
 - WORKER_NAME
 dependencies:
-- gearmand
 - gearman-admin
 team: eng-ip
 resources:


### PR DESCRIPTION
**JIRA**:

**Overview**:

**Testing**:

**Roll Out**:
- [ ] This repo will auto deploy after you merge. To do a manual deploy, use ark start -e production s3-to-redshift or ark start -e production s3-to-redshift-fast


