### PR TITLE
Look up configs by table name

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -163,18 +163,19 @@ func (r *Redshift) GetTableFromConf(f s3filepath.S3File) (*Table, error) {
 	}
 
 	// data we want is nested in a map - possible to have multiple tables in a conf file
-	t, ok := tempSchema[f.Table]
-	if !ok {
-		return nil, fmt.Errorf("can't find table in conf")
-	}
-	if t.Meta.Schema != f.Schema {
-		return nil, fmt.Errorf("mismatched schema, conf: %s, file: %s", t.Meta.Schema, f.Schema)
-	}
-	if t.Meta.DataDateColumn == "" {
-		return nil, fmt.Errorf("data date column must be set")
-	}
+	for _, config := range tempSchema {
+		if config.Name == f.Table {
+			if config.Meta.Schema != f.Schema {
+				return nil, fmt.Errorf("mismatched schema, conf: %s, file: %s", config.Meta.Schema, f.Schema)
+			}
+			if config.Meta.DataDateColumn == "" {
+				return nil, fmt.Errorf("data date column must be set")
+			}
 
-	return &t, nil
+			return &config, nil
+		}
+	}
+	return nil, fmt.Errorf("can't find table in conf")
 }
 
 // GetTableMetadata looks for a table and returns both the Table representation


### PR DESCRIPTION
**JIRA**: No JIRA

**Overview**:

Changed map key lookup to iteration looking at the destination table name instead of just the config key. 

We've had a couple of instances lately of people trying to set up mongo-to-redshift jobs and running into the issue that, under the current system, the config key has to be the same as the destination table name in order for the workflow to do its thing. I believe this strict (and incorrect) lookup to be the culprit. Example failure: https://production--hubble.int.clever.com/mongo-to-redshift:master/workflows/w/a824301f-6748-4d33-a0d9-126403456a42/jobs

**Testing**: 😬 

**Roll Out**:
- [ ] This repo will auto deploy after you merge. To do a manual deploy, use ark start -e production s3-to-redshift or ark start -e production s3-to-redshift-fast


