### PR TITLE
Add thresholds for analyze

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,10 +219,10 @@ func runCopy(
 		cleanupArgs := map[string]string{
 			"targets":     inputConf.Schema + `."` + inputTable.Name + `"`,
 			"vacuum_mode": "delete",
-		}
-		// If we truncated, run an analyze as well
-		if truncate {
-			cleanupArgs["analyze_mode"] = "full"
+			// If we truncated, analyze will run regardless since 100% of the rows have changed. Otherwise,
+			// only analyze if we've changed enough rows (threshold > 1%)
+			"analyze_mode":      "full",
+			"analyze_threshold": "1",
 		}
 
 		payload, err := json.Marshal(cleanupArgs)


### PR DESCRIPTION
**JIRA**:
https://clever.atlassian.net/browse/IPOC-1345

**Overview**:
`redshift-cleanup` already defaults to vacuum full (so we were running it all the time regardless, but this will make it more explicit. hmlfvs analyze was taking up to a hour at some points and we run it every hour, so it clogs up the pipeline.

Also, truncate would naturally hit a 100% threshold anyway so this really just makes it so we skip extra analyzes that might not be necessary. (we analyze schemas at 0.001% every day already).

Related to https://github.com/Clever/redshift-cleanup/pull/44

Alternatively, we can make the non-truncate skip analyzing