### PR TITLE
Update table metadata query to allow for the primary key to be involved in other constraints.

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -100,14 +100,14 @@ const (
       ELSE ''
   END AS default_val,
   f.attnotnull AS not_null,
-  p.contype IS NOT NULL AND p.contype = 'p' AS primary_key,
+  p.contype IS NOT NULL AS primary_key,
   f.attisdistkey AS dist_key,
   f.attsortkeyord AS sort_ord
 FROM pg_attribute f
   JOIN pg_class c ON c.oid = f.attrelid
   LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = f.attnum
   LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
-  LEFT JOIN pg_constraint p ON p.conrelid = c.oid AND f.attnum = ANY (p.conkey)
+  LEFT JOIN pg_constraint p ON p.conrelid = c.oid AND f.attnum = ANY (p.conkey) AND p.contype = 'p'
 WHERE c.relkind = 'r'::char
     AND n.nspname = '%s'  -- Replace with schema name
     AND c.relname = '%s'  -- Replace with table name


### PR DESCRIPTION
The problem: I'm adding more constraints (uniqueness, foreign keys, etc) to our tables, which is causing things to get messed up. This is because our query currently does a poor join, and rows for keys would get duplicated if there were multiple constraints for that column. This fixes that.

Before:
```
      name       |          col_type           | default_val | not_null | primary_key | dist_key | sort_
-----------------+-----------------------------+-------------+----------+-------------+----------+------
 _data_timestamp | timestamp without time zone |             | f        | f           | f        |      
 id              | character varying(256)      |             | t        | f           | f        |      
 id              | character varying(256)      |             | t        | t           | f        |      
 district_id     | character varying(256)      |             | t        | f           | t        |      
 district_id     | character varying(256)      |             | t        | f           | t        |      
```

After:
```
      name       |          col_type           | default_val | not_null | primary_key | dist_key | sort_
 _data_timestamp | timestamp without time zone |             | f        | f           | f        |      
 id              | character varying(256)      |             | t        | t           | f        |      
 district_id     | character varying(256)      |             | t        | f           | t        |      
```