### PR TITLE
Create new s3-to-redshift-key-metrics resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,6 @@ jobs:
     - run: make test
     - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
     - run: $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS s3-to-redshift
+    - run: $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS s3-to-redshift-key-metrics
     - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS s3-to-redshift production no-confirm-deploy; fi;
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS s3-to-redshift-key-metrics production no-confirm-deploy; fi;

--- a/launch/s3-to-redshift-key-metrics.yml
+++ b/launch/s3-to-redshift-key-metrics.yml
@@ -1,0 +1,29 @@
+run:
+  type: docker
+env:
+- AWS_REGION
+- GEARMAN_ADMIN_USER
+- GEARMAN_ADMIN_PASS
+- GEARMAN_ADMIN_PATH
+- REDSHIFT_USER
+- REDSHIFT_PASSWORD
+- REDSHIFT_PORT
+- REDSHIFT_HOST
+- REDSHIFT_ROLE_ARN
+- REDSHIFT_DB
+- CLEANUP_WORKER
+- FIREHOSE_EVENTS_ANALYTICS_PIPELINE_JOB_RUNS
+dependencies:
+- gearman-admin
+team: eng-ip
+resources:
+  cpu: 0.05
+  max_mem: 0.05
+aws:
+  custom: true
+  managed:
+    clever:
+    - Workflows
+  s3:
+    read:
+      - long-term-metrics


### PR DESCRIPTION
**Overview**: Hoping to have some workflows avoid the long s3-to-redshift queue, much like we do with some rtp steps using redshift-to-postgres-key-metrics.

Goes with https://github.com/Clever/ark-config/pull/2742
