### PR TITLE
prod to podOnly

### DIFF
--- a/launch/s3-to-redshift-key-metrics.yml
+++ b/launch/s3-to-redshift-key-metrics.yml
@@ -32,4 +32,4 @@ pod_config:
     migrationState: podOnly
   group: us-west-2
   prod:
-    migrationState: homepod
+    migrationState: podOnly

--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -37,4 +37,4 @@ pod_config:
     migrationState: podOnly
   group: us-west-2
   prod:
-    migrationState: homepod
+    migrationState: podOnly


### PR DESCRIPTION
This PR is the second step in migrating this worker to pods

To check before merging
- If this worker has elastic ip(s) associated then close this PR and contact oncall-infra

This PR will
- deploy the worker to pods in production

After the steps below this worker will be doing approximately 50% of the work from the pod deployment in prod

After merging this PR once the deploy is complete
1. Verify deploy was succesful and that there were no container exits. This can be done by looking at container count in grafana (go/workers)
2. Use [signalfx dashboard](https://app.signalfx.com/#/dashboard/DL8uwWYAcAA?startTime=-12h&endTime=Now&variables%5B%5D=resource%3Dresource:) to look at task success rate for all the workers getting migrated

In case of errors
1. revert this PR
2. merge the deploy
