### PR TITLE
both to noHomepod

### DIFF
--- a/launch/s3-to-redshift-key-metrics.yml
+++ b/launch/s3-to-redshift-key-metrics.yml
@@ -28,8 +28,4 @@ aws:
     read:
     - long-term-metrics
 pod_config:
-  dev:
-    migrationState: podOnly
   group: us-west-2
-  prod:
-    migrationState: podOnly

--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -33,8 +33,4 @@ autoscaling:
   min_count: 2
   max_count: 4
 pod_config:
-  dev:
-    migrationState: podOnly
   group: us-west-2
-  prod:
-    migrationState: podOnly


### PR DESCRIPTION
This PR is the last step in migrating this worker to pods

This PR will
- update config to stop deploying in homepod

We have already migrated the worker to pods in dev and prod so there are no risks in this PR.

After merging this PR once the deploy is complete
1. `ark stop <app> -e clever-dev --kill-homepod`
2. `ark stop <app> -e production --kill-homepod`
