### PR TITLE
migrate workers to app mesh in mesh_only state in prod

### DIFF
--- a/launch/s3-to-redshift-key-metrics.yml
+++ b/launch/s3-to-redshift-key-metrics.yml
@@ -36,3 +36,5 @@ deploy_config:
 mesh_config:
   dev:
     state: mesh_only
+  prod:
+    state: mesh_only

--- a/launch/s3-to-redshift.yml
+++ b/launch/s3-to-redshift.yml
@@ -41,3 +41,5 @@ deploy_config:
 mesh_config:
   dev:
     state: mesh_only
+  prod:
+    state: mesh_only


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5056

**Overview:**
In this PR we will migrate all workers in this repo to use app mesh. We are migrating this worker to mesh_only state directly instead of hybrid as workers don't have albs and hybrid state is not valid for them.

After this PR is merged the workers will start running with a envoy proxy sidecar which will handle all the networking. As applications haven't been migrated to the mesh yet, this change should not cause a significant difference.

**Rollout:**
- Workers have no upstreams so nothing to do here other than merge PR and monitor dapple deploy
- monitor cpu and memory
